### PR TITLE
Reorganize and test Lithium

### DIFF
--- a/interestingness/ximport.py
+++ b/interestingness/ximport.py
@@ -1,8 +1,11 @@
 # This lets you import an interestingness test given a full path, or given just a filename
 # (assuming it's in the current directory OR in the same directory as ximport)
 
+import logging
 import os
 import sys
+
+log = logging.getLogger("lithium")
 
 def importRelativeOrAbsolute(f):
     # maybe there's a way to do this more sanely with the |imp| module...
@@ -19,10 +22,10 @@ def importRelativeOrAbsolute(f):
         sys.path.append(".")
     try:
         module = __import__(f)
-    except ImportError, e:
-        print "Failed to import: " + f
-        print "From: " + __file__
-        print str(e)
+    except ImportError as e:
+        log.error("Failed to import: " + f)
+        log.error("From: " + __file__)
+        log.error(e)
         raise
     sys.path.pop()
     return module

--- a/lithium/examples/arithmetic/product_divides.py
+++ b/lithium/examples/arithmetic/product_divides.py
@@ -9,17 +9,17 @@ import sys
 def interesting(args, tempPrefix):
     mod = int(args[0])
     filename = args[1]
-    
-    file = open(filename, "r")
+
     prod = 1
-    for line in file:
-        line = line.strip()
-        if line.isdigit():
-            prod *= int(line)
-                
+    with open(filename, "r") as input_fp:
+        for line in input_fp:
+            line = line.strip()
+            if line.isdigit():
+                prod *= int(line)
+
     if prod % mod == 0:
-        print str(prod) + " is divisible by " + str(mod)
+        sys.stdout.write("%d is divisible by %d\n" % (prod, mod))
         return True
     else:
-        print str(prod) + " is not divisible by " + str(mod)
+        sys.stdout.write("%d is not divisible by %d\n" % (prod, mod))
         return False

--- a/lithium/lithium.py
+++ b/lithium/lithium.py
@@ -1,416 +1,497 @@
 #!/usr/bin/env python
+# coding=utf-8
 
 import argparse
+import logging
 import os
 import time
 import sys
 
-path0 = os.path.dirname(os.path.realpath(__file__))
-path1 = os.path.abspath(os.path.join(path0, os.pardir, 'interestingness'))
-sys.path.append(path1)
-import ximport
+
+log = logging.getLogger("lithium") # pylint: disable=invalid-name
 
 
-# Globals
-strategy = "minimize"
-minimizeRepeat = "last"
-minimizeMin = 1
-minimizeMax = pow(2, 30)
-minimizeChunkStart = 0
-minimizeRepeatFirstRound = False
-
-atom = "line"
-
-conditionScript = None
-conditionArgs = None
-testcaseFilename = None
-testcaseExtension = ""
-
-testCount = 0
-testTotal = 0
-
-tempDir = None
-tempFileCount = 1
-
-before = ""
-after = ""
-parts = []
-interestingParts = None
-stopAfterTime = None
+class LithiumError(Exception):
+    pass
 
 
-def main():
-    global conditionScript, conditionArgs, testcaseFilename, testcaseExtension, strategy, parts, interestingParts
+class Testcase(object):
 
-    readTestcase()
+    def __init__(self):
+        self.before = b""
+        self.after = b""
+        self.parts = []
 
-    if hasattr(conditionScript, "init"):
-        conditionScript.init(conditionArgs)
+        self.filename = None
+        self.extension = None
 
-    try:
+    def copy(self):
+        new = type(self)()
 
-        if not tempDir:
-            createTempDir()
-            print "Intermediate files will be stored in " + tempDir + os.sep + "."
+        new.before = self.before
+        new.after = self.after
+        new.parts = self.parts[:]
 
-        if strategy == "check-only":
-            r = interesting(parts, writeIt=False)
-            print 'Lithium result: ' + ('interesting.' if r else 'not interesting.')
-            return
+        new.filename = self.filename
+        new.extension = self.extension
 
-        strategyFunction = {
-            'minimize': minimize
-        }.get(strategy, None)
-
-        if not strategyFunction:
-            usageError("Unknown strategy!")
-
-        print "The original testcase has " + quantity(len(parts), atom) + "."
-        print "Checking that the original testcase is 'interesting'..."
-        if not interesting(parts, writeIt=False):
-            print "Lithium result: the original testcase is not 'interesting'!"
-            return
-
-        if len(parts) == 0:
-            print "The file has " + quantity(0, atom) + " so there's nothing for Lithium to try to remove!"
-
-        writeTestcaseTemp("original", False)
-        strategyFunction()
-
-    finally:
-        if hasattr(conditionScript, "cleanup"):
-            conditionScript.cleanup(conditionArgs)
-        # Make sure we exit with an interesting testcase
-        if interestingParts is not None:
-            parts = interestingParts
-            writeTestcase(testcaseFilename)
+        return new
 
 
+    def readTestcase(self, filename):
+        hasDDSection = False
 
-def processOptions():
-    global atom, conditionArgs, conditionScript, strategy, testcaseExtension, testcaseFilename, tempDir
-    global minimizeRepeat, minimizeMin, minimizeMax, minimizeChunkStart, minimizeRepeatFirstRound, stopAfterTime
+        self.__init__()
+        self.filename = filename
+        self.extension = os.path.splitext(self.filename)[1]
 
-    parser = argparse.ArgumentParser(
-        description="Lithium, an automated testcase reduction tool by Jesse Ruderman.",
-        epilog="See doc/using.html for more information.",
-        usage="./lithium.py [options] condition [condition options] file-to-reduce\n\n"
-              "example: "
-              "./lithium.py crashes 120 ~/tracemonkey/js/src/debug/js -j a.js\n"
-              "    Lithium will reduce a.js subject to the condition that the following\n"
-              "    crashes in 120 seconds:\n"
-              "    ~/tracemonkey/js/src/debug/js -j a.js")
-    grp_opt = parser.add_argument_group(description="Lithium options")
-    grp_opt.add_argument(
-        "--testcase",
-        help="testcase file. default: last argument is used.")
-    grp_opt.add_argument(
-        "--tempdir",
-        help="specify the directory to use as temporary directory.")
-    grp_opt.add_argument(
-        "-c", "--char",
-        action="store_true",
-        help="Don't treat lines as atomic units; treat the file as a sequence of characters rather than a sequence of lines.")
-    grp_opt.add_argument(
-        "--strategy",
-        default="minimize",
-        choices=["minimize", "check-only"],
-        help="reduction strategy to use. default: minimize")
-    grp_add = parser.add_argument_group(description="Additional options for the default strategy")
-    grp_add.add_argument(
-        "--min", type=int,
-        default=1,
-        help="must be a power of two. default: 1")
-    grp_add.add_argument(
-        "--max", type=int,
-        default=pow(2, 30),
-        help="must be a power of two. default: about half of the file")
-    grp_add.add_argument(
-        "--repeat",
-        default="last",
-        choices=["always", "last", "never"],
-        help="Whether to repeat a chunk size if chunks are removed. default: last")
-    grp_add.add_argument(
-        "--chunksize", type=int,
-        default=None,
-        help="Shortcut for repeat=never, min=n, max=n. chunk size must be a power of two.")
-    grp_add.add_argument(
-        "--chunkstart", type=int,
-        default=0,
-        help="For the first round only, start n chars/lines into the file. Best for max to divide n. [Mostly intended for internal use]")
-    grp_add.add_argument(
-        "--repeatfirstround", default=False, action="store_true",
-        help="Treat the first round as if it removed chunks; possibly repeat it.  [Mostly intended for internal use]")
-    grp_add.add_argument(
-        "--maxruntime", type=int,
-        default=None,
-        help="If reduction takes more than n seconds, stop (and print instructions for continuing).")
-    grp_ext = parser.add_argument_group(description="Condition, condition options and file-to-reduce")
-    grp_ext.add_argument(
-        "extra_args",
-        action="append",
-        nargs=argparse.REMAINDER,
-        help="condition [condition options] file-to-reduce")
-
-    args = parser.parse_args()
-
-    tempDir = args.tempdir
-    atom = "char" if args.char else "line"
-    strategy = args.strategy
-    if args.chunksize:
-        minimizeMin = args.chunksize
-        minimizeMax = args.chunksize
-        minimizeRepeat = "never"
-    else:
-        minimizeMin = args.min
-        minimizeMax = args.max
-        minimizeRepeat = args.repeat
-    minimizeChunkStart = args.chunkstart
-    minimizeRepeatFirstRound = args.repeatfirstround
-    if args.maxruntime:
-        stopAfterTime = time.time() + args.maxruntime
-    extra_args = args.extra_args[0]
-
-    if args.testcase:
-        testcaseFilename = args.testcase
-    elif len(extra_args) > 0:
-        testcaseFilename = extra_args[-1]  # can be overridden by --testcase in processOptions
-    else:
-        print "No testcase specified (use --testcase or last condition arg)"
-        return False
-
-    testcaseExtension = os.path.splitext(testcaseFilename)[1]
-
-    if not isPowerOfTwo(minimizeMin) or not isPowerOfTwo(minimizeMax):
-        print "Min/Max must be powers of two."
-        return False
-
-    conditionScript = ximport.importRelativeOrAbsolute(extra_args[0])
-    conditionArgs = extra_args[1:]
-
-    return True
-
-
-def usageError(s):
-    print "=== LITHIUM SUMMARY ==="
-    print s
-    raise Exception(s)
-
-
-# Functions for manipulating the testcase (aka the 'interesting' file)
-def readTestcase():
-    hasDDSection = False
-
-    with open(testcaseFilename, "r") as f:
-        # Determine whether the f has a DDBEGIN..DDEND section.
-        for line in f:
-            if line.find("DDEND") != -1:
-                usageError("The testcase (" + testcaseFilename + ") has a line containing 'DDEND' without a line containing 'DDBEGIN' before it.")
-            if line.find("DDBEGIN") != -1:
-                hasDDSection = True
-                break
-
-        f.seek(0)
-
-        if hasDDSection:
-            # Reduce only the part of the file between 'DDBEGIN' and 'DDEND',
-            # leaving the rest unchanged.
-            # print "Testcase has a DD section"
-            readTestcaseWithDDSection(f)
-        else:
-            # Reduce the entire file.
-            # print "Testcase does not have a DD section"
+        with open(self.filename, "rb") as f:
+            # Determine whether the f has a DDBEGIN..DDEND section.
             for line in f:
-                readTestcaseLine(line)
+                if line.find(b"DDEND") != -1:
+                    raise LithiumError("The testcase (%s) has a line containing 'DDEND' without a line containing 'DDBEGIN' before it.", self.filename)
+                if line.find(b"DDBEGIN") != -1:
+                    hasDDSection = True
+                    break
 
-    global parts, interestingParts
-    interestingParts = parts
+            f.seek(0)
 
-def readTestcaseWithDDSection(f):
-    global before, after
-    global parts
-
-    for line in f:
-        before += line
-        if line.find("DDBEGIN") != -1:
-            break
-
-    for line in f:
-        if line.find("DDEND") != -1:
-            after += line
-            break
-        readTestcaseLine(line)
-    else:
-        usageError("The testcase (" + testcaseFilename + ") has a line containing 'DDBEGIN' but no line containing 'DDEND'.")
-
-    for line in f:
-        after += line
-
-    if atom == "char" and len(parts) > 0:
-        # Move the line break at the end of the last line out of the reducible
-        # part so the "DDEND" line doesn't get combined with another line.
-        parts.pop()
-        after = "\n" + after
-
-
-def readTestcaseLine(line):
-    global atom
-    global parts
-
-    if atom == "line":
-        parts.append(line)
-    elif atom == "char":
-        for char in line:
-            parts.append(char)
-
-
-def writeTestcase(filename):
-    with open(filename, "w") as f:
-        f.write(before)
-        f.writelines(parts)
-        f.write(after)
-
-
-def writeTestcaseTemp(partialFilename, useNumber):
-    global tempFileCount
-    if useNumber:
-        partialFilename = str(tempFileCount) + "-" + partialFilename
-        tempFileCount += 1
-    writeTestcase(tempDir + os.sep + partialFilename + testcaseExtension)
-
-
-def createTempDir():
-    global tempDir
-    i = 1
-    while True:
-        tempDir = "tmp" + str(i)
-        # To avoid race conditions, we use try/except instead of exists/create
-        # Hopefully we don't get any errors other than "File exists" :)
-        try:
-            os.mkdir(tempDir)
-            break
-        except OSError:
-            i += 1
-
-
-# If the file is still interesting after the change, changes the global "parts" and returns True.
-def interesting(partsSuggestion, writeIt=True):
-    global tempFileCount, testcaseFilename, conditionArgs
-    global testCount, testTotal
-    global parts, interestingParts
-    oldParts = parts  # would rather be less side-effecty about this, and be passing partsSuggestion around
-    parts = partsSuggestion
-
-    if writeIt:
-        writeTestcase(testcaseFilename)
-
-    testCount += 1
-    testTotal += len(parts)
-
-    tempPrefix = tempDir + os.sep + str(tempFileCount)
-    inter = conditionScript.interesting(conditionArgs, tempPrefix)
-
-    # Save an extra copy of the file inside the temp directory.
-    # This is useful if you're reducing an assertion and encounter a crash:
-    # it gives you a way to try to reproduce the crash.
-    if tempDir:
-        tempFileTag = "interesting" if inter else "boring"
-        writeTestcaseTemp(tempFileTag, True)
-
-    if inter:
-        interestingParts = parts
-    else:
-        parts = oldParts
-    return inter
-
-
-# Main reduction algorithm
-def minimize():
-    global parts, testCount, testTotal
-    global minimizeMax, minimizeMin, minimizeChunkStart, minimizeRepeatFirstRound
-    origNumParts = len(parts)
-    chunkSize = min(minimizeMax, largestPowerOfTwoSmallerThan(origNumParts))
-    finalChunkSize = min(chunkSize, max(minimizeMin, 1))
-    chunkStart = minimizeChunkStart
-    anyChunksRemoved = minimizeRepeatFirstRound
-
-    while True:
-        if stopAfterTime and time.time() > stopAfterTime:
-            # Not all switches will be copied!  Be sure to add --tempdir, --maxruntime if desired.
-            # Not using shellify() here because of the strange requirements of bot.py's lithium-command.txt.
-            print "Lithium result: please perform another pass using the same arguments"
-            break
-
-        if chunkStart >= len(parts):
-            writeTestcaseTemp("did-round-" + str(chunkSize), True)
-            last = (chunkSize == finalChunkSize)
-            empty = (len(parts) == 0)
-            print ""
-            if not empty and anyChunksRemoved and (minimizeRepeat == "always" or (minimizeRepeat == "last" and last)):
-                chunkStart = 0
-                print "Starting another round of chunk size " + str(chunkSize)
-            elif empty or last:
-                print "Lithium result: succeeded, reduced to: " + quantity(len(parts), atom)
-                break
+            if hasDDSection:
+                # Reduce only the part of the file between 'DDBEGIN' and 'DDEND',
+                # leaving the rest unchanged.
+                # log.info("Testcase has a DD section")
+                self.readTestcaseWithDDSection(f)
             else:
-                chunkStart = 0
-                chunkSize /= 2
-                print "Halving chunk size to " + str(chunkSize)
-            anyChunksRemoved = False
+                # Reduce the entire file.
+                # log.info("Testcase does not have a DD section")
+                for line in f:
+                    self.readTestcaseLine(line)
 
-        chunkEnd = min(len(parts), chunkStart + chunkSize)
-        description = "Removing a chunk of size " + str(chunkSize) + " starting at " + str(chunkStart) + " of " + str(len(parts))
-        if interesting(parts[:chunkStart] + parts[chunkEnd:]):
-            print description + " was a successful reduction :)"
-            anyChunksRemoved = True
-            # leave chunkStart the same
+
+    def readTestcaseWithDDSection(self, f):
+        for line in f:
+            self.before += line
+            if line.find(b"DDBEGIN") != -1:
+                break
+
+        for line in f:
+            if line.find(b"DDEND") != -1:
+                self.after += line
+                break
+            self.readTestcaseLine(line)
         else:
-            print description + " made the file 'uninteresting'."
-            chunkStart += chunkSize
+            raise LithiumError("The testcase (%s) has a line containing 'DDBEGIN' but no line containing 'DDEND'.", self.filename)
 
-    writeTestcase(testcaseFilename)
+        for line in f:
+            self.after += line
 
-    print "=== LITHIUM SUMMARY ==="
-    if chunkSize == 1 and not anyChunksRemoved and minimizeRepeat != "never":
-        print "  Removing any single " + atom + " from the final file makes it uninteresting!"
 
-    print "  Initial size: " + quantity(origNumParts, atom)
-    print "  Final size: " + quantity(len(parts), atom)
-    print "  Tests performed: " + str(testCount)
-    print "  Test total: " + quantity(testTotal, atom)
+    def readTestcaseLine(self, line):
+        raise NotImplementedError()
+
+
+    def writeTestcase(self, filename=None):
+        raise NotImplementedError()
+
+
+class TestcaseLine(Testcase):
+    atom = "line"
+
+    def readTestcaseLine(self, line):
+        self.parts.append(line)
+
+
+    def writeTestcase(self, filename=None):
+        if filename is None:
+            filename = self.filename
+        with open(filename, "wb") as f:
+            f.write(self.before)
+            f.writelines(self.parts)
+            f.write(self.after)
+
+
+class TestcaseChar(TestcaseLine):
+    atom = "char"
+
+    def readTestcaseWithDDSection(self, f):
+        Testcase.readTestcaseWithDDSection(self, f)
+
+        if len(self.parts) > 0:
+            # Move the line break at the end of the last line out of the reducible
+            # part so the "DDEND" line doesn't get combined with another line.
+            self.parts.pop()
+            self.after = "\n" + self.after
+
+
+    def readTestcaseLine(self, line):
+        for char in line:
+            self.parts.append(char)
+
+
+class Strategy(object):
+    """
+    Minimization strategy
+
+    This should implement a main() method which takes a testcase and calls the interesting callback repeatedly to minimize the testcase.
+    """
+
+    def addArgs(self, parser):
+        pass
+
+    def processArgs(self, parser, args):
+        pass
+
+    def main(self, testcase, interesting, tempFilename):
+        raise NotImplementedError()
+
+
+class CheckOnly(Strategy):
+    name = "check-only"
+
+    def main(self, testcase, interesting, tempFilename):
+        r = interesting(testcase, writeIt=False)
+        log.info("Lithium result: %s", ("interesting." if r else "not interesting."))
+        return 0
+
+
+class Minimize(Strategy):
+    name = "minimize"
+
+    def __init__(self):
+        self.minimizeRepeat = "last"
+        self.minimizeMin = 1
+        self.minimizeMax = pow(2, 30)
+        self.minimizeChunkStart = 0
+        self.minimizeChunkSize = None
+        self.minimizeRepeatFirstRound = False
+        self.stopAfterTime = None
+
+    def addArgs(self, parser):
+        grp_add = parser.add_argument_group(description="Additional options for the %s strategy" % self.name)
+        grp_add.add_argument(
+            "--min", type=int,
+            default=1,
+            help="must be a power of two. default: 1")
+        grp_add.add_argument(
+            "--max", type=int,
+            default=pow(2, 30),
+            help="must be a power of two. default: about half of the file")
+        grp_add.add_argument(
+            "--repeat",
+            default="last",
+            choices=["always", "last", "never"],
+            help="Whether to repeat a chunk size if chunks are removed. default: last")
+        grp_add.add_argument(
+            "--chunksize", type=int,
+            default=None,
+            help="Shortcut for repeat=never, min=n, max=n. chunk size must be a power of two.")
+        grp_add.add_argument(
+            "--chunkstart", type=int,
+            default=0,
+            help="For the first round only, start n chars/lines into the file. Best for max to divide n. [Mostly intended for internal use]")
+        grp_add.add_argument(
+            "--repeatfirstround", action="store_true",
+            help="Treat the first round as if it removed chunks; possibly repeat it.  [Mostly intended for internal use]")
+        grp_add.add_argument(
+            "--maxruntime", type=int,
+            default=None,
+            help="If reduction takes more than n seconds, stop (and print instructions for continuing).")
+
+    def processArgs(self, parser, args):
+        if args.chunksize:
+            self.minimizeMin = args.chunksize
+            self.minimizeMax = args.chunksize
+            self.minimizeRepeat = "never"
+        else:
+            self.minimizeMin = args.min
+            self.minimizeMax = args.max
+            self.minimizeRepeat = args.repeat
+        self.minimizeChunkStart = args.chunkstart
+        self.minimizeRepeatFirstRound = args.repeatfirstround
+        if args.maxruntime:
+            self.stopAfterTime = time.time() + args.maxruntime
+        if not isPowerOfTwo(self.minimizeMin) or not isPowerOfTwo(self.minimizeMax):
+            parser.error("Min/Max must be powers of two.")
+
+    # Main reduction algorithm
+    def main(self, testcase, interesting, tempFilename):
+        log.info("The original testcase has %s.", quantity(len(testcase.parts), testcase.atom))
+        log.info("Checking that the original testcase is 'interesting'...")
+        if not interesting(testcase, writeIt=False):
+            log.info("Lithium result: the original testcase is not 'interesting'!")
+            return 1
+
+        if len(testcase.parts) == 0:
+            log.info("The file has %s so there's nothing for Lithium to try to remove!", quantity(0, testcase.atom))
+
+        testcase.writeTestcase(tempFilename("original", False))
+
+        origNumParts = len(testcase.parts)
+        chunkSize = min(self.minimizeMax, largestPowerOfTwoSmallerThan(origNumParts))
+        finalChunkSize = min(chunkSize, max(self.minimizeMin, 1))
+        chunkStart = self.minimizeChunkStart
+        anyChunksRemoved = self.minimizeRepeatFirstRound
+
+        while True:
+            if self.stopAfterTime and time.time() > self.stopAfterTime:
+                # Not all switches will be copied!  Be sure to add --tempdir, --maxruntime if desired.
+                # Not using shellify() here because of the strange requirements of bot.py's lithium-command.txt.
+                log.info("Lithium result: please perform another pass using the same arguments")
+                break
+
+            if chunkStart >= len(testcase.parts):
+                testcase.writeTestcase(tempFilename("did-round-%d" % chunkSize))
+                last = (chunkSize == finalChunkSize)
+                empty = (len(testcase.parts) == 0)
+                log.info("")
+                if not empty and anyChunksRemoved and (self.minimizeRepeat == "always" or (self.minimizeRepeat == "last" and last)):
+                    chunkStart = 0
+                    log.info("Starting another round of chunk size %d", chunkSize)
+                elif empty or last:
+                    log.info("Lithium result: succeeded, reduced to: %s", quantity(len(testcase.parts), testcase.atom))
+                    break
+                else:
+                    chunkStart = 0
+                    chunkSize >>= 1
+                    log.info("Halving chunk size to %d", chunkSize)
+                anyChunksRemoved = False
+
+            chunkEnd = min(len(testcase.parts), chunkStart + chunkSize)
+            description = "Removing a chunk of size %d starting at %d of %d" % (chunkSize, chunkStart, len(testcase.parts))
+            testcaseSuggestion = testcase.copy()
+            testcaseSuggestion.parts = testcaseSuggestion.parts[:chunkStart] + testcaseSuggestion.parts[chunkEnd:]
+            if interesting(testcaseSuggestion):
+                testcase = testcaseSuggestion
+                log.info("%s was a successful reduction :)", description)
+                anyChunksRemoved = True
+                # leave chunkStart the same
+            else:
+                log.info("%s made the file 'uninteresting'.", description)
+                chunkStart += chunkSize
+
+        testcase.writeTestcase()
+
+        summaryHeader()
+
+        if chunkSize == 1 and not anyChunksRemoved and self.minimizeRepeat != "never":
+            log.info("  Removing any single %s from the final file makes it uninteresting!", testcase.atom)
+
+        log.info("  Initial size: %s", quantity(origNumParts, testcase.atom))
+        log.info("  Final size: %s", quantity(len(testcase.parts), testcase.atom))
+
+        return 0
+
+
+class Lithium(object):
+
+    def __init__(self):
+
+        self.strategy = None
+
+        self.conditionScript = None
+        self.conditionArgs = None
+
+        self.testCount = 0
+        self.testTotal = 0
+
+        self.tempDir = None
+
+        self.testcase = None
+        self.lastInteresting = None
+
+        self.tempFileCount = 1
+
+
+    def main(self):
+        logging.basicConfig(format="%(message)s", level=logging.INFO)
+        self.processArgs()
+
+        try:
+            return self.run()
+
+        except LithiumError as e:
+            summaryHeader()
+            log.error(e)
+            return 1
+
+
+    def run(self):
+        if hasattr(self.conditionScript, "init"):
+            self.conditionScript.init(self.conditionArgs)
+
+        try:
+            if not self.tempDir:
+                self.createTempDir()
+                log.info("Intermediate files will be stored in %s%s.", self.tempDir, os.sep)
+
+            result = self.strategy.main(self.testcase, self.interesting, self.testcaseTempFilename)
+
+            log.info("  Tests performed: %d", self.testCount)
+            log.info("  Test total: %s", quantity(self.testTotal, self.testcase.atom))
+
+            return result
+
+        finally:
+            if hasattr(self.conditionScript, "cleanup"):
+                self.conditionScript.cleanup(self.conditionArgs)
+
+            # Make sure we exit with an interesting testcase
+            if self.lastInteresting is not None:
+                self.lastInteresting.writeTestcase()
+
+
+    def processArgs(self):
+        # Build list of strategies and testcase types
+        strategies = {}
+        testcaseTypes = {}
+        for cls in globals().values():
+            if isinstance(cls, type):
+                if cls is not Strategy and issubclass(cls, Strategy):
+                    assert cls.name not in strategies
+                    strategies[cls.name] = cls
+                elif cls is not Testcase and issubclass(cls, Testcase):
+                    assert cls.atom not in testcaseTypes
+                    testcaseTypes[cls.atom] = cls
+
+        # Try to parse --conflict before anything else
+        class ArgParseTry(argparse.ArgumentParser):
+            def exit(subself, **kwds): # pylint: disable=no-self-argument
+                pass
+            def error(subself, message): # pylint: disable=no-self-argument
+                pass
+
+        defaultStrategy = "minimize"
+        assert defaultStrategy in strategies
+        parser = ArgParseTry(add_help=False)
+        parser.add_argument(
+            "--strategy",
+            default=defaultStrategy,
+            choices=strategies.keys())
+        args = parser.parse_known_args()
+        self.strategy = strategies.get(args[0].strategy if args else None, strategies[defaultStrategy])()
+
+        parser = argparse.ArgumentParser(
+            description="Lithium, an automated testcase reduction tool by Jesse Ruderman.",
+            epilog="See doc/using.html for more information.",
+            usage="./lithium.py [options] condition [condition options] file-to-reduce\n\n"
+                  "example: "
+                  "./lithium.py crashes 120 ~/tracemonkey/js/src/debug/js -j a.js\n"
+                  "    Lithium will reduce a.js subject to the condition that the following\n"
+                  "    crashes in 120 seconds:\n"
+                  "    ~/tracemonkey/js/src/debug/js -j a.js")
+        grp_opt = parser.add_argument_group(description="Lithium options")
+        grp_opt.add_argument(
+            "--testcase",
+            help="testcase file. default: last argument is used.")
+        grp_opt.add_argument(
+            "--tempdir",
+            help="specify the directory to use as temporary directory.")
+        grp_opt.add_argument(
+            "-c", "--char",
+            action="store_true",
+            help="Don't treat lines as atomic units; treat the file as a sequence of characters rather than a sequence of lines.")
+        grp_opt.add_argument(
+            "--strategy",
+            default=self.strategy.name, # this has already been parsed above, it's only here for the help message
+            choices=strategies.keys(),
+            help="reduction strategy to use. default: %s" % defaultStrategy)
+        self.strategy.addArgs(parser)
+        grp_ext = parser.add_argument_group(description="Condition, condition options and file-to-reduce")
+        grp_ext.add_argument(
+            "extra_args",
+            action="append",
+            nargs=argparse.REMAINDER,
+            help="condition [condition options] file-to-reduce")
+
+        args = parser.parse_args()
+        self.strategy.processArgs(parser, args)
+
+        self.tempDir = args.tempdir
+        atom = "char" if args.char else "line"
+        extra_args = args.extra_args[0]
+
+        if args.testcase:
+            testcaseFilename = args.testcase
+        elif len(extra_args) > 0:
+            testcaseFilename = extra_args[-1]  # can be overridden by --testcase in processOptions
+        else:
+            parser.error("No testcase specified (use --testcase or last condition arg)")
+        self.testcase = testcaseTypes[atom]()
+        self.testcase.readTestcase(testcaseFilename)
+
+        sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "interestingness")))
+        import ximport # pylint: disable=import-error
+
+        self.conditionScript = ximport.importRelativeOrAbsolute(extra_args[0])
+        self.conditionArgs = extra_args[1:]
+
+
+    def testcaseTempFilename(self, partialFilename, useNumber=True):
+        if useNumber:
+            partialFilename = "%d-%s" % (self.tempFileCount, partialFilename)
+            self.tempFileCount += 1
+        return os.path.join(self.tempDir, partialFilename + self.testcase.extension)
+
+
+    def createTempDir(self):
+        i = 1
+        while True:
+            self.tempDir = "tmp%d" % i
+            # To avoid race conditions, we use try/except instead of exists/create
+            # Hopefully we don't get any errors other than "File exists" :)
+            try:
+                os.mkdir(self.tempDir)
+                break
+            except OSError:
+                i += 1
+
+
+    # If the file is still interesting after the change, changes "parts" and returns True.
+    def interesting(self, testcaseSuggestion, writeIt=True):
+        if writeIt:
+            testcaseSuggestion.writeTestcase()
+
+        self.testCount += 1
+        self.testTotal += len(testcaseSuggestion.parts)
+
+        tempPrefix = os.path.join(self.tempDir, "%d" % self.tempFileCount)
+        inter = self.conditionScript.interesting(self.conditionArgs, tempPrefix)
+
+        # Save an extra copy of the file inside the temp directory.
+        # This is useful if you're reducing an assertion and encounter a crash:
+        # it gives you a way to try to reproduce the crash.
+        if self.tempDir:
+            tempFileTag = "interesting" if inter else "boring"
+            testcaseSuggestion.writeTestcase(self.testcaseTempFilename(tempFileTag))
+
+        if inter:
+            self.testcase = testcaseSuggestion
+            self.lastInteresting = self.testcase
+
+        return inter
 
 
 # Helpers
-def divideRoundingUp(n, d):
-    return (n // d) + (1 if n % d != 0 else 0)
+
+def summaryHeader():
+    log.info("=== LITHIUM SUMMARY ===")
 
 
 def isPowerOfTwo(n):
-    i = 1
-    while True:
-        if i == n:
-            return True
-        if i > n:
-            return False
-        i *= 2
+    return (1<<(n.bit_length() - 1)) == n
 
 
 def largestPowerOfTwoSmallerThan(n):
-    i = 1
-    while True:
-        if i * 2 >= n:
-            return i
-        i *= 2
+    return 1<<(n.bit_length() - 2)
 
 
-def quantity(n, s):
-    """Convert a quantity to a string, with correct pluralization."""
-    r = str(n) + " " + s
+def quantity(n, unit):
+    "Convert a quantity to a string, with correct pluralization."
+    r = "%d %s" % (n, unit)
     if n != 1:
         r += "s"
     return r
 
 
 if __name__ == "__main__":
-    if processOptions():
-        main()
+    exit(Lithium().main())

--- a/lithium/lithium.py
+++ b/lithium/lithium.py
@@ -615,7 +615,7 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
                     nSquare = square[midChunkIdx]
                     nNormal = normal[midChunkIdx]
                     if nCurly != 0 or nSquare != 0 or nNormal != 0:
-                        log.info("Keepping %s because it is 'uninteresting'.", description)
+                        log.info("Keeping %s because it is 'uninteresting'.", description)
                         chunkMidStart += chunkSize
                         midChunkIdx = self.list_nindex(summary, midChunkIdx, "S")
                         continue

--- a/lithium/lithium.py
+++ b/lithium/lithium.py
@@ -147,7 +147,7 @@ class TestcaseSymbol(TestcaseLine):
 
 
     def readTestcaseLine(self, line):
-        cutter = b'[%(before)s]?[^%(before)s%(after)s]*(?:[%(after)s]|$|(?=[%(before)s]))' % {b'before': self.cutBefore, b'after': self.cutAfter}
+        cutter = b"[%(before)s]?[^%(before)s%(after)s]*(?:[%(after)s]|$|(?=[%(before)s]))" % {b"before": self.cutBefore, b"after": self.cutAfter}
         for statement in re.finditer(cutter, line):
             if statement.group(0):
                 self.parts.append(statement.group(0))
@@ -399,7 +399,7 @@ class MinimizeSurroundingPairs(Minimize):
 
         log.info("Starting a round with chunks of %s.", quantity(chunkSize, testcase.atom))
 
-        summary = ['S' for i in range(numChunks)]
+        summary = ["S" for i in range(numChunks)]
         chunkStart = chunkSize
         beforeChunkIdx = 0
         keepChunkIdx = 1
@@ -421,20 +421,20 @@ class MinimizeSurroundingPairs(Minimize):
                     chunksRemoved += 2
                     atomsRemoved += (chunkBefEnd - chunkBefStart)
                     atomsRemoved += (chunkAftEnd - chunkAftStart)
-                    summary[beforeChunkIdx] = '-'
-                    summary[afterChunkIdx] = '-'
+                    summary[beforeChunkIdx] = "-"
+                    summary[afterChunkIdx] = "-"
                     # The start is now sooner since we remove the chunk which was before this one.
                     chunkStart -= chunkSize
                     try:
                         # Try to keep removing surrounding chunks of the same part.
-                        beforeChunkIdx = self.list_rindex(summary, keepChunkIdx, 'S')
+                        beforeChunkIdx = self.list_rindex(summary, keepChunkIdx, "S")
                     except ValueError:
                         # There is no more survinving block on the left-hand-side of
                         # the current chunk, shift everything by one surviving
                         # block. Any ValueError from here means that there is no
                         # longer enough chunk.
                         beforeChunkIdx = keepChunkIdx
-                        keepChunkIdx = self.list_nindex(summary, keepChunkIdx, 'S')
+                        keepChunkIdx = self.list_nindex(summary, keepChunkIdx, "S")
                         chunkStart += chunkSize
                 else:
                     log.info("Removing %s made the file 'uninteresting'.", description)
@@ -444,7 +444,7 @@ class MinimizeSurroundingPairs(Minimize):
                     keepChunkIdx = afterChunkIdx
                     chunkStart += chunkSize
 
-                afterChunkIdx = self.list_nindex(summary, keepChunkIdx, 'S')
+                afterChunkIdx = self.list_nindex(summary, keepChunkIdx, "S")
 
         except ValueError:
             # This is a valid loop exit point.
@@ -454,7 +454,7 @@ class MinimizeSurroundingPairs(Minimize):
         printableSummary = " ".join(["".join(summary[(2 * i):min(2 * (i + 1), numChunks + 1)]) for i in range(numChunks // 2 + numChunks % 2)])
         log.info("")
         log.info("Done with a round of chunk size %d!", chunkSize)
-        log.info("%s survived; %s removed.", quantity(summary.count('S'), "chunk"), quantity(summary.count('-'), "chunk"))
+        log.info("%s survived; %s removed.", quantity(summary.count("S"), "chunk"), quantity(summary.count("-"), "chunk"))
         log.info("%s survived; %s removed.", quantity(atomsSurviving, testcase.atom), quantity(atomsRemoved, testcase.atom))
         log.info("Which chunks survived: %s", printableSummary)
         log.info("")
@@ -509,10 +509,10 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
 
         log.info("Starting a round with chunks of %s.", quantity(chunkSize, testcase.atom))
 
-        summary = ['S' for i in range(numChunks)]
-        curly = [(testcase.parts[i].count(b'{') - testcase.parts[i].count(b'}')) for i in range(numChunks)]
-        square = [(testcase.parts[i].count(b'[') - testcase.parts[i].count(b']')) for i in range(numChunks)]
-        normal = [(testcase.parts[i].count(b'(') - testcase.parts[i].count(b')')) for i in range(numChunks)]
+        summary = ["S" for i in range(numChunks)]
+        curly = [(testcase.parts[i].count(b"{") - testcase.parts[i].count(b"}")) for i in range(numChunks)]
+        square = [(testcase.parts[i].count(b"[") - testcase.parts[i].count(b"]")) for i in range(numChunks)]
+        normal = [(testcase.parts[i].count(b"(") - testcase.parts[i].count(b")")) for i in range(numChunks)]
         chunkStart = 0
         lhsChunkIdx = 0
 
@@ -521,7 +521,7 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
 
                 description = "chunk #%d%s of %d chunks of size %d" % (lhsChunkIdx, "".join(" " for i in range(len(str(lhsChunkIdx)) + 4)), numChunks, chunkSize)
 
-                assert summary[:lhsChunkIdx].count('S') * chunkSize == chunkStart, "the chunkStart should correspond to the lhsChunkIdx modulo the removed chunks."
+                assert summary[:lhsChunkIdx].count("S") * chunkSize == chunkStart, "the chunkStart should correspond to the lhsChunkIdx modulo the removed chunks."
 
                 chunkLhsStart = chunkStart
                 chunkLhsEnd = min(len(testcase.parts), chunkLhsStart + chunkSize)
@@ -539,18 +539,18 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
                         log.info("Yay, reduced it by removing %s :)", description)
                         chunksRemoved += 1
                         atomsRemoved += (chunkLhsEnd - chunkLhsStart)
-                        summary[lhsChunkIdx] = '-'
+                        summary[lhsChunkIdx] = "-"
                     else:
                         log.info("Removing %s made the file 'uninteresting'.", description)
                         chunkStart += chunkSize
-                    lhsChunkIdx = self.list_nindex(summary, lhsChunkIdx, 'S')
+                    lhsChunkIdx = self.list_nindex(summary, lhsChunkIdx, "S")
                     continue
 
                 # Otherwise look for the corresponding chunk.
                 rhsChunkIdx = lhsChunkIdx
                 for item in summary[(lhsChunkIdx + 1):]:
                     rhsChunkIdx += 1
-                    if item != 'S':
+                    if item != "S":
                         continue
                     nCurly += curly[rhsChunkIdx]
                     nSquare += square[rhsChunkIdx]
@@ -564,11 +564,11 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
                 if nCurly != 0 or nSquare != 0 or nNormal != 0:
                     log.info("Skipping %s because it is 'uninteresting'.", description)
                     chunkStart += chunkSize
-                    lhsChunkIdx = self.list_nindex(summary, lhsChunkIdx, 'S')
+                    lhsChunkIdx = self.list_nindex(summary, lhsChunkIdx, "S")
                     continue
 
                 # Otherwise we do have a match and we check if this is interesting to remove both.
-                chunkRhsStart = chunkLhsStart + chunkSize * summary[lhsChunkIdx:rhsChunkIdx].count('S')
+                chunkRhsStart = chunkLhsStart + chunkSize * summary[lhsChunkIdx:rhsChunkIdx].count("S")
                 chunkRhsStart = min(len(testcase.parts), chunkRhsStart)
                 chunkRhsEnd = min(len(testcase.parts), chunkRhsStart + chunkSize)
 
@@ -582,9 +582,9 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
                     chunksRemoved += 2
                     atomsRemoved += (chunkLhsEnd - chunkLhsStart)
                     atomsRemoved += (chunkRhsEnd - chunkRhsStart)
-                    summary[lhsChunkIdx] = '-'
-                    summary[rhsChunkIdx] = '-'
-                    lhsChunkIdx = self.list_nindex(summary, lhsChunkIdx, 'S')
+                    summary[lhsChunkIdx] = "-"
+                    summary[rhsChunkIdx] = "-"
+                    lhsChunkIdx = self.list_nindex(summary, lhsChunkIdx, "S")
                     continue
 
                 # Removing the braces make the failure disappear.  As we are looking
@@ -597,15 +597,15 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
                 # If you want to try it, just replace this True by a False.
                 if True:
                     chunkStart += chunkSize
-                    lhsChunkIdx = self.list_nindex(summary, lhsChunkIdx, 'S')
+                    lhsChunkIdx = self.list_nindex(summary, lhsChunkIdx, "S")
                     continue
 
                 origChunkIdx = lhsChunkIdx
                 stayOnSameChunk = False
                 chunkMidStart = chunkLhsEnd
-                midChunkIdx = self.list_nindex(summary, lhsChunkIdx, 'S')
+                midChunkIdx = self.list_nindex(summary, lhsChunkIdx, "S")
                 while chunkMidStart < chunkRhsStart:
-                    assert summary[:midChunkIdx].count('S') * chunkSize == chunkMidStart, "the chunkMidStart should correspond to the midChunkIdx modulo the removed chunks."
+                    assert summary[:midChunkIdx].count("S") * chunkSize == chunkMidStart, "the chunkMidStart should correspond to the midChunkIdx modulo the removed chunks."
                     description = "chunk #%d%s of %d chunks of size %d" % (midChunkIdx, "".join(" " for i in range(len(str(lhsChunkIdx)) + 4)), numChunks, chunkSize)
 
                     chunkMidEnd = chunkMidStart + chunkSize
@@ -617,7 +617,7 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
                     if nCurly != 0 or nSquare != 0 or nNormal != 0:
                         log.info("Keepping %s because it is 'uninteresting'.", description)
                         chunkMidStart += chunkSize
-                        midChunkIdx = self.list_nindex(summary, midChunkIdx, 'S')
+                        midChunkIdx = self.list_nindex(summary, midChunkIdx, "S")
                         continue
 
                     # Try moving the chunk after.
@@ -638,7 +638,7 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
                         square =  ts[0] + ts[1] + ts[3] + ts[2] + ts[4]
                         normal =  tn[0] + tn[1] + tn[3] + tn[2] + tn[4]
                         rhsChunkIdx -= 1
-                        midChunkIdx = summary[midChunkIdx:].index('S') + midChunkIdx
+                        midChunkIdx = summary[midChunkIdx:].index("S") + midChunkIdx
                         continue
 
                     # Try moving the chunk before.
@@ -658,18 +658,18 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
                         square =  ts[0] + ts[2] + ts[1] + ts[3] + ts[4]
                         normal =  tn[0] + tn[2] + tn[1] + tn[3] + tn[4]
                         lhsChunkIdx += 1
-                        midChunkIdx = self.list_nindex(summary, midChunkIdx, 'S')
+                        midChunkIdx = self.list_nindex(summary, midChunkIdx, "S")
                         stayOnSameChunk = True
                         continue
 
                     log.info("..Moving %s made the file 'uninteresting'.", description)
                     chunkMidStart += chunkSize
-                    midChunkIdx = self.list_nindex(summary, midChunkIdx, 'S')
+                    midChunkIdx = self.list_nindex(summary, midChunkIdx, "S")
 
                 lhsChunkIdx = origChunkIdx
                 if not stayOnSameChunk:
                     chunkStart += chunkSize
-                    lhsChunkIdx = self.list_nindex(summary, lhsChunkIdx, 'S')
+                    lhsChunkIdx = self.list_nindex(summary, lhsChunkIdx, "S")
 
 
         except ValueError:
@@ -680,7 +680,7 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
         printableSummary = " ".join("".join(summary[(2 * i):min(2 * (i + 1), numChunks + 1)]) for i in range(numChunks // 2 + numChunks % 2))
         log.info("")
         log.info("Done with a round of chunk size %d!", chunkSize)
-        log.info("%s survived; %s removed.", quantity(summary.count('S'), "chunk"), quantity(summary.count('-'), "chunk"))
+        log.info("%s survived; %s removed.", quantity(summary.count("S"), "chunk"), quantity(summary.count("-"), "chunk"))
         log.info("%s survived; %s removed.", quantity(atomsSurviving, testcase.atom), quantity(atomsRemoved, testcase.atom))
         log.info("Which chunks survived: %s", printableSummary)
         log.info("")
@@ -765,7 +765,7 @@ class ReplacePropertiesByGlobals(Minimize):
         # Map words to the chunk indexes in which they are present.
         words = {}
         for chunk, line in enumerate(testcase.parts):
-            for match in re.finditer(br'(?<=[\w\d_])\.(\w+)', line):
+            for match in re.finditer(br"(?<=[\w\d_])\.(\w+)", line):
                 word = match.group(1)
                 if not word in words:
                     words[word] = [chunk]
@@ -777,7 +777,7 @@ class ReplacePropertiesByGlobals(Minimize):
             return 0, testcase
 
         log.info("Starting a round with chunks of %s.", quantity(chunkSize, testcase.atom))
-        summary = ['S' for i in range(numChunks)]
+        summary = ["S" for i in range(numChunks)]
 
         for word, chunks in list(words.items()):
             chunkIndexes = {}
@@ -808,7 +808,7 @@ class ReplacePropertiesByGlobals(Minimize):
                     testcase = newTC
                     log.info("Yay, reduced it by removing prefixes of %s :)", description)
                     numRemovedChars += maybeRemoved
-                    summary[chunkIdx] = 's'
+                    summary[chunkIdx] = "s"
                     words[word] = [c for c in chunks if c not in chunkIndexes]
                     if len(words[word]) == 0:
                         del words[word]
@@ -819,7 +819,7 @@ class ReplacePropertiesByGlobals(Minimize):
         printableSummary = " ".join("".join(summary[(2 * i):min(2 * (i + 1), numChunks + 1)]) for i in range(numChunks // 2 + numChunks % 2))
         log.info("")
         log.info("Done with a round of chunk size %d!", chunkSize)
-        log.info("%s survived; %s shortened.", quantity(summary.count('S'), "chunk"), quantity(summary.count('s'), "chunk"))
+        log.info("%s survived; %s shortened.", quantity(summary.count("S"), "chunk"), quantity(summary.count("s"), "chunk"))
         log.info("%s survived; %s removed.", quantity(numSurvivingChars, "character"), quantity(numRemovedChars, "character"))
         log.info("Which chunks survived: %s", printableSummary)
         log.info("")
@@ -883,7 +883,7 @@ class ReplaceArgumentsByGlobals(Minimize):
         anonymousStack = []
         for chunk, line in enumerate(testcase.parts):
             # Match function definition with at least one argument.
-            for match in re.finditer(br'(?:function\s+(\w+)|(\w+)\s*=\s*function)\s*\((\s*\w+\s*(?:,\s*\w+\s*)*)\)', line):
+            for match in re.finditer(br"(?:function\s+(\w+)|(\w+)\s*=\s*function)\s*\((\s*\w+\s*(?:,\s*\w+\s*)*)\)", line):
                 fun = match.group(1)
                 if fun is None:
                     fun = match.group(2)
@@ -891,7 +891,7 @@ class ReplaceArgumentsByGlobals(Minimize):
                 if match.group(3) == b"":
                     args = []
                 else:
-                    args = match.group(3).split(b',')
+                    args = match.group(3).split(b",")
 
                 if not fun in functions:
                     functions[fun] = {"defs": args, "argsPattern": match.group(3), "chunk": chunk, "uses": []}
@@ -901,15 +901,15 @@ class ReplaceArgumentsByGlobals(Minimize):
                     functions[fun]["chunk"] = chunk
 
             # Match anonymous function definition, which are surrounded by parentheses.
-            for match in re.finditer(br'\(function\s*\w*\s*\(((?:\s*\w+\s*(?:,\s*\w+\s*)*)?)\)\s*{', line):
+            for match in re.finditer(br"\(function\s*\w*\s*\(((?:\s*\w+\s*(?:,\s*\w+\s*)*)?)\)\s*{", line):
                 if match.group(1) == "":
                     args = []
                 else:
-                    args = match.group(1).split(',')
+                    args = match.group(1).split(",")
                 anonymousStack += [{"defs": args, "chunk": chunk, "use": None, "useChunk": 0}]
 
             # Match calls of anonymous function.
-            for match in re.finditer(br'}\s*\)\s*\(((?:[^()]|\([^,()]*\))*)\)', line):
+            for match in re.finditer(br"}\s*\)\s*\(((?:[^()]|\([^,()]*\))*)\)", line):
                 if len(anonymousStack) == 0:
                     continue
                 anon = anonymousStack[-1]
@@ -919,19 +919,19 @@ class ReplaceArgumentsByGlobals(Minimize):
                 if match.group(1) == b"":
                     args = []
                 else:
-                    args = match.group(1).split(b',')
+                    args = match.group(1).split(b",")
                 anon["use"] = args
                 anon["useChunk"] = chunk
                 anonymousQueue += [anon]
 
             # match function calls. (and some definitions)
-            for match in re.finditer(br'((\w+)\s*\(((?:[^()]|\([^,()]*\))*)\))', line):
+            for match in re.finditer(br"((\w+)\s*\(((?:[^()]|\([^,()]*\))*)\))", line):
                 pattern = match.group(1)
                 fun = match.group(2)
                 if match.group(3) == b"":
                     args = []
                 else:
-                    args = match.group(3).split(b',')
+                    args = match.group(3).split(b",")
                 if not fun in functions:
                     functions[fun] = {"uses": []}
                 functions[fun]["uses"] += [{"values": args, "chunk": chunk, "pattern": pattern}]

--- a/lithium/lithium.py
+++ b/lithium/lithium.py
@@ -364,17 +364,17 @@ class MinimizeSurroundingPairs(Minimize):
     @staticmethod
     def list_rindex(l, p, e):
         if p < 0 or p > len(l):
-            raise ValueError("%s is not in list" % str(e))
+            raise ValueError("%s is not in list" % e)
         for index, item in enumerate(reversed(l[:p])):
             if item == e:
                 return p - index - 1
-        raise ValueError("%s is not in list" % str(e))
+        raise ValueError("%s is not in list" % e)
 
 
     @staticmethod
     def list_nindex(l, p, e):
         if p + 1 >= len(l):
-            raise ValueError("%s is not in list" % str(e))
+            raise ValueError("%s is not in list" % e)
         return l[(p + 1):].index(e) + (p + 1)
 
 
@@ -459,7 +459,7 @@ class MinimizeSurroundingPairs(Minimize):
         log.info("Which chunks survived: %s", printableSummary)
         log.info("")
 
-        testcase.writeTestcase(tempFilename("did-round-" + str(chunkSize)))
+        testcase.writeTestcase(tempFilename("did-round-%d" % chunkSize))
 
         return (chunksRemoved > 0), testcase
 
@@ -802,14 +802,14 @@ class ReplacePropertiesByGlobals(Minimize):
                 for chunkStart in chunkStarts:
                     subst = re.sub(br"[\w_.]+\." + word, word, newTC.parts[chunkStart])
                     maybeRemoved += len(newTC.parts[chunkStart]) - len(subst)
-                    newTC.parts = newTC.parts[:chunkStart] + [ subst ] + newTC.parts[(chunkStart+1):]
+                    newTC.parts = newTC.parts[:chunkStart] + [subst] + newTC.parts[(chunkStart+1):]
 
                 if interesting(newTC):
                     testcase = newTC
                     log.info("Yay, reduced it by removing prefixes of %s :)", description)
                     numRemovedChars += maybeRemoved
                     summary[chunkIdx] = 's'
-                    words[word] = [ c for c in chunks if c not in chunkIndexes ]
+                    words[word] = [c for c in chunks if c not in chunkIndexes]
                     if len(words[word]) == 0:
                         del words[word]
                 else:
@@ -819,9 +819,9 @@ class ReplacePropertiesByGlobals(Minimize):
         printableSummary = " ".join("".join(summary[(2 * i):min(2 * (i + 1), numChunks + 1)]) for i in range(numChunks // 2 + numChunks % 2))
         log.info("")
         log.info("Done with a round of chunk size %d!", chunkSize)
-        log.info(quantity(summary.count('S'), "chunk") + " survived; " + quantity(summary.count('s'), "chunk") + " shortened.")
-        log.info(quantity(numSurvivingChars, "character") + " survived; " + quantity(numRemovedChars, "character") + " removed.")
-        log.info("Which chunks survived: " + printableSummary)
+        log.info("%s survived; %s shortened.", quantity(summary.count('S'), "chunk"), quantity(summary.count('s'), "chunk"))
+        log.info("%s survived; %s removed.", quantity(numSurvivingChars, "character"), quantity(numRemovedChars, "character"))
+        log.info("Which chunks survived: %s", printableSummary)
         log.info("")
 
         testcase.writeTestcase(tempFilename("did-round-%d" % chunkSize))
@@ -894,7 +894,7 @@ class ReplaceArgumentsByGlobals(Minimize):
                     args = match.group(3).split(b',')
 
                 if not fun in functions:
-                    functions[fun] = { "defs": args, "argsPattern": match.group(3), "chunk": chunk, "uses": [] }
+                    functions[fun] = {"defs": args, "argsPattern": match.group(3), "chunk": chunk, "uses": []}
                 else:
                     functions[fun]["defs"] = args
                     functions[fun]["argsPattern"] = match.group(3)
@@ -906,7 +906,7 @@ class ReplaceArgumentsByGlobals(Minimize):
                     args = []
                 else:
                     args = match.group(1).split(',')
-                anonymousStack += [{ "defs": args, "chunk": chunk, "use": None, "useChunk": 0 }]
+                anonymousStack += [{"defs": args, "chunk": chunk, "use": None, "useChunk": 0}]
 
             # Match calls of anonymous function.
             for match in re.finditer(br'}\s*\)\s*\(((?:[^()]|\([^,()]*\))*)\)', line):
@@ -933,8 +933,8 @@ class ReplaceArgumentsByGlobals(Minimize):
                 else:
                     args = match.group(3).split(b',')
                 if not fun in functions:
-                    functions[fun] = { "uses": [] }
-                functions[fun]["uses"] += [{ "values": args, "chunk": chunk, "pattern": pattern }]
+                    functions[fun] = {"uses": []}
+                functions[fun]["uses"] += [{"values": args, "chunk": chunk, "pattern": pattern}]
 
         # All patterns have been removed sucessfully.
         if len(functions) == 0 and len(anonymousQueue) == 0:
@@ -955,7 +955,7 @@ class ReplaceArgumentsByGlobals(Minimize):
             argDefs = argsMap["defs"]
             defChunk = argsMap["chunk"]
             subst = newTC.parts[defChunk].replace(argsMap["argsPattern"], b"", 1)
-            newTC.parts = newTC.parts[:defChunk] + [ subst ] + newTC.parts[(defChunk+1):]
+            newTC.parts = newTC.parts[:defChunk] + [subst] + newTC.parts[(defChunk+1):]
 
             # Copy callers arguments to globals.
             for argUse in argsMap["uses"]:
@@ -965,9 +965,9 @@ class ReplaceArgumentsByGlobals(Minimize):
                     continue
                 while len(values) < len(argDefs):
                     values = values + [b"undefined"]
-                setters = b"".join([ a + b" = " + v + b";\n" for a, v in zip(argDefs, values) ])
+                setters = b"".join(b"%s = %s;\n" % (a, v) for a, v in zip(argDefs, values))
                 subst = setters + newTC.parts[chunk]
-                newTC.parts = newTC.parts[:chunk] + [ subst ] + newTC.parts[(chunk+1):]
+                newTC.parts = newTC.parts[:chunk] + [subst] + newTC.parts[(chunk+1):]
             maybeMovedArguments += len(argDefs)
 
             if interesting(newTC):
@@ -988,10 +988,10 @@ class ReplaceArgumentsByGlobals(Minimize):
                 subst = newTC.parts[chunk].replace(argUse["pattern"], fun + b"()", 1)
                 if newTC.parts[chunk] == subst:
                     continue
-                newTC.parts = newTC.parts[:chunk] + [ subst ] + newTC.parts[(chunk+1):]
+                newTC.parts = newTC.parts[:chunk] + [subst] + newTC.parts[(chunk+1):]
                 maybeMovedArguments = len(values)
 
-                descriptionChunk = description + " at " + testcase.atom + " #" + str(chunk)
+                descriptionChunk = "%s at %s #%d" % (description, testcase.atom, chunk)
                 if interesting(newTC):
                     testcase = newTC
                     log.info("Yay, reduced it by removing %s :)", descriptionChunk)
@@ -1010,28 +1010,28 @@ class ReplaceArgumentsByGlobals(Minimize):
             defChunk = anon["chunk"]
             values = anon["use"]
             chunk = anon["useChunk"]
-            description = "arguments of anonymous function at #" + testcase.atom + " " + str(defChunk)
+            description = "arguments of anonymous function at #%s %d" % (testcase.atom, defChunk)
 
             # Remove arguments of the function.
             subst = newTC.parts[defChunk].replace(b",".join(argDefs), b"", 1)
             if newTC.parts[defChunk] == subst:
                 noopChanges += 1
-            newTC.parts = newTC.parts[:defChunk] + [ subst ] + newTC.parts[(defChunk+1):]
+            newTC.parts = newTC.parts[:defChunk] + [subst] + newTC.parts[(defChunk+1):]
 
             # Replace arguments by their value in the scope of the function.
             while len(values) < len(argDefs):
                 values = values + [b"undefined"]
-            setters = "".join([ b"var " + a + b" = " + v + b";\n" for a, v in zip(argDefs, values) ])
+            setters = "".join(b"var %s = %s;\n" % (a, v) for a, v in zip(argDefs, values))
             subst = newTC.parts[defChunk] + b"\n" + setters
             if newTC.parts[defChunk] == subst:
                 noopChanges += 1
-            newTC.parts = newTC.parts[:defChunk] + [ subst ] + newTC.parts[(defChunk+1):]
+            newTC.parts = newTC.parts[:defChunk] + [subst] + newTC.parts[(defChunk+1):]
 
             # Remove arguments of the anonymous function call.
             subst = newTC.parts[chunk].replace(b",".join(anon["use"]), b"", 1)
             if newTC.parts[chunk] == subst:
                 noopChanges += 1
-            newTC.parts = newTC.parts[:chunk] + [ subst ] + newTC.parts[(chunk+1):]
+            newTC.parts = newTC.parts[:chunk] + [subst] + newTC.parts[(chunk+1):]
             maybeMovedArguments += len(values)
 
             if noopChanges == 3:
@@ -1167,7 +1167,7 @@ class Lithium(object):
         grp_atoms.add_argument(
             "-s", "--symbol",
             action="store_true",
-            help="Treat the file as a sequence of strings separated by tokens. " + \
+            help="Treat the file as a sequence of strings separated by tokens. "
                  "The characters by which the strings are delimited are defined by the --cutBefore, and --cutAfter options.")
         grp_opt.add_argument(
             "--cutBefore",

--- a/lithium/lithium.py
+++ b/lithium/lithium.py
@@ -131,12 +131,14 @@ class TestcaseChar(TestcaseLine):
 
 class TestcaseSymbol(TestcaseLine):
     atom = "symbol-delimiter"
+    DEFAULT_CUT_AFTER = b"?=;{["
+    DEFAULT_CUT_BEFORE = b"]}:"
 
     def __init__(self):
         TestcaseSymbol.__init__(self)
 
-        self.cutAfter = "?=;{["
-        self.cutBefore = "]}:"
+        self.cutAfter = self.DEFAULT_CUT_AFTER
+        self.cutBefore = self.DEFAULT_CUT_BEFORE
 
 
     def readTestcaseLine(self, line):
@@ -1165,6 +1167,14 @@ class Lithium(object):
             help="Treat the file as a sequence of strings separated by tokens. " + \
                  "The characters by which the strings are delimited are defined by the --cutBefore, and --cutAfter options.")
         grp_opt.add_argument(
+            "--cutBefore",
+            default=TestcaseSymbol.DEFAULT_CUT_BEFORE,
+            help="See --symbol. default: %s" % TestcaseSymbol.DEFAULT_CUT_BEFORE.decode("utf-8"))
+        grp_opt.add_argument(
+            "--cutAfter",
+            default=TestcaseSymbol.DEFAULT_CUT_AFTER,
+            help="See --symbol. default: %s" % TestcaseSymbol.DEFAULT_CUT_AFTER.decode("utf-8"))
+        grp_opt.add_argument(
             "--strategy",
             default=self.strategy.name, # this has already been parsed above, it's only here for the help message
             choices=strategies.keys(),
@@ -1183,6 +1193,7 @@ class Lithium(object):
         self.tempDir = args.tempdir
         atom = TestcaseChar.atom if args.char else TestcaseLine.atom
         atom = TestcaseSymbol.atom if args.symbol else atom
+
         extra_args = args.extra_args[0]
 
         if args.testcase:
@@ -1192,6 +1203,9 @@ class Lithium(object):
         else:
             parser.error("No testcase specified (use --testcase or last condition arg)")
         self.testcase = testcaseTypes[atom]()
+        if args.symbol:
+            self.testcase.cutBefore = args.cutBefore
+            self.testcase.cutAfter = args.cutAfter
         self.testcase.readTestcase(testcaseFilename)
 
         sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "interestingness")))

--- a/lithium/lithium.py
+++ b/lithium/lithium.py
@@ -383,11 +383,9 @@ class MinimizeSurroundingPairs(Minimize):
 
         Returns True iff any chunks were removed."""
 
-        chunksSoFar = 0
         summary = ""
 
         chunksRemoved = 0
-        chunksSurviving = 0
         atomsRemoved = 0
 
         atomsInitial = len(testcase.parts)
@@ -484,8 +482,8 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
     #
 
     @staticmethod
-    def list_fiveParts(list, step, f, s, t):
-        return (list[:f], list[f:s], list[s:(s+step)], list[(s+step):(t+step)], list[(t+step):])
+    def list_fiveParts(lst, step, f, s, t):
+        return (lst[:f], lst[f:s], lst[s:(s+step)], lst[(s+step):(t+step)], lst[(t+step):])
 
 
     def tryRemovingChunks(self, chunkSize, testcase, interesting, tempFilename):
@@ -493,11 +491,9 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
 
         Returns True iff any chunks were removed."""
 
-        chunksSoFar = 0
         summary = ""
 
         chunksRemoved = 0
-        chunksSurviving = 0
         atomsRemoved = 0
 
         atomsInitial = len(testcase.parts)
@@ -608,7 +604,6 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
                     assert summary[:midChunkIdx].count("S") * chunkSize == chunkMidStart, "the chunkMidStart should correspond to the midChunkIdx modulo the removed chunks."
                     description = "chunk #%d%s of %d chunks of size %d" % (midChunkIdx, "".join(" " for i in range(len(str(lhsChunkIdx)) + 4)), numChunks, chunkSize)
 
-                    chunkMidEnd = chunkMidStart + chunkSize
                     p = self.list_fiveParts(testcase.parts, chunkSize, chunkLhsStart, chunkMidStart, chunkRhsStart)
 
                     nCurly = curly[midChunkIdx]
@@ -776,7 +771,7 @@ class ReplacePropertiesByGlobals(Minimize):
             return 0, testcase
 
         log.info("Starting a round with chunks of %s.", quantity(chunkSize, testcase.atom))
-        summary = ["S" for i in range(numChunks)]
+        summary = list("S" * numChunks)
 
         for word, chunks in list(words.items()):
             chunkIndexes = {}

--- a/lithium/lithium.py
+++ b/lithium/lithium.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
+# pylint: disable=invalid-name,missing-docstring,line-too-long,too-many-locals,too-many-statements,too-many-branches,too-many-lines,too-many-instance-attributes,too-many-arguments
 
 import argparse
 import logging
@@ -591,7 +592,7 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
 
                 # Moving chunks is still a bit experimental, and it can introduce reducing loops.
                 # If you want to try it, just replace this True by a False.
-                if True:
+                if True: # pylint: disable=using-constant-test
                     chunkStart += chunkSize
                     lhsChunkIdx = self.list_nindex(summary, lhsChunkIdx, "S")
                     continue
@@ -623,6 +624,7 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
                         log.info("->Moving %s kept the file 'interesting'.", description)
                         chunkRhsStart -= chunkSize
                         chunkRhsEnd -= chunkSize
+                        # pylint: disable=bad-whitespace
                         tS = self.list_fiveParts(summary, 1, lhsChunkIdx, midChunkIdx, rhsChunkIdx)
                         tc = self.list_fiveParts(curly  , 1, lhsChunkIdx, midChunkIdx, rhsChunkIdx)
                         ts = self.list_fiveParts(square , 1, lhsChunkIdx, midChunkIdx, rhsChunkIdx)
@@ -643,6 +645,7 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
                         chunkLhsStart += chunkSize
                         chunkLhsEnd += chunkSize
                         chunkMidStart += chunkSize
+                        # pylint: disable=bad-whitespace
                         tS = self.list_fiveParts(summary, 1, lhsChunkIdx, midChunkIdx, rhsChunkIdx)
                         tc = self.list_fiveParts(curly  , 1, lhsChunkIdx, midChunkIdx, rhsChunkIdx)
                         ts = self.list_fiveParts(square , 1, lhsChunkIdx, midChunkIdx, rhsChunkIdx)
@@ -749,8 +752,6 @@ class ReplacePropertiesByGlobals(Minimize):
         """Make a single run through the testcase, trying to remove chunks of size chunkSize.
 
         Returns True iff any chunks were removed."""
-
-        summary = ""
 
         numRemovedChars = 0
         numChunks = divideRoundingUp(len(testcase.parts), chunkSize)
@@ -863,7 +864,8 @@ class ReplaceArgumentsByGlobals(Minimize):
         return 0, False, testcase
 
 
-    def tryArgumentsAsGlobals(self, roundNum, testcase, interesting, tempFilename):
+    @staticmethod
+    def tryArgumentsAsGlobals(roundNum, testcase, interesting, tempFilename):
         """Make a single run through the testcase, trying to remove chunks of size chunkSize.
 
         Returns True iff any chunks were removed."""
@@ -1015,7 +1017,7 @@ class ReplaceArgumentsByGlobals(Minimize):
             # Replace arguments by their value in the scope of the function.
             while len(values) < len(argDefs):
                 values = values + [b"undefined"]
-            setters = "".join(b"var %s = %s;\n" % (a, v) for a, v in zip(argDefs, values))
+            setters = b"".join(b"var %s = %s;\n" % (a, v) for a, v in zip(argDefs, values))
             subst = newTC.parts[defChunk] + b"\n" + setters
             if newTC.parts[defChunk] == subst:
                 noopChanges += 1
@@ -1137,7 +1139,7 @@ class Lithium(object):
         args = parser.parse_known_args(argv)
         self.strategy = strategies.get(args[0].strategy if args else None, strategies[defaultStrategy])()
 
-        parser = argparse.ArgumentParser(
+        parser = argparse.ArgumentParser( # pylint: disable=redefined-variable-type
             description="Lithium, an automated testcase reduction tool by Jesse Ruderman.",
             epilog="See doc/using.html for more information.",
             usage="./lithium.py [options] condition [condition options] file-to-reduce\n\n"

--- a/lithium/lithium.py
+++ b/lithium/lithium.py
@@ -621,12 +621,11 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
                         continue
 
                     # Try moving the chunk after.
-
                     testcaseSuggestion = testcase.copy()
                     testcaseSuggestion.parts = p[0] + p[1] + p[3] + p[2] + p[4]
                     if interesting(testcaseSuggestion):
                         testcase = testcaseSuggestion
-                        log.info("->Moving %s kept the file 'interesting'.")
+                        log.info("->Moving %s kept the file 'interesting'.", description)
                         chunkRhsStart -= chunkSize
                         chunkRhsEnd -= chunkSize
                         tS = self.list_fiveParts(summary, 1, lhsChunkIdx, midChunkIdx, rhsChunkIdx)
@@ -795,7 +794,7 @@ class ReplacePropertiesByGlobals(Minimize):
                 if len(chunkStarts) == 1 and finalChunkSize != chunkSize:
                     continue
 
-                description = "'%s' in chunk #%d of %d chunks of size %d" % (word, chunkIdx, numChunks, chunkSize)
+                description = "'%s' in chunk #%d of %d chunks of size %d" % (word.decode("utf-8", "replace"), chunkIdx, numChunks, chunkSize)
 
                 maybeRemoved = 0
                 newTC = testcase.copy()

--- a/lithium/lithium.py
+++ b/lithium/lithium.py
@@ -799,7 +799,7 @@ class ReplacePropertiesByGlobals(Minimize):
                 maybeRemoved = 0
                 newTC = testcase.copy()
                 for chunkStart in chunkStarts:
-                    subst = re.sub(br"[\w_.]+\." + word, word, newTC.parts[chunkStart])
+                    subst = re.sub(br"[\w_.]+\.%s" % word, word, newTC.parts[chunkStart])
                     maybeRemoved += len(newTC.parts[chunkStart]) - len(subst)
                     newTC.parts = newTC.parts[:chunkStart] + [subst] + newTC.parts[(chunkStart+1):]
 

--- a/lithium/tests.py
+++ b/lithium/tests.py
@@ -1,0 +1,176 @@
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+import lithium
+
+
+class TestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpd = tempfile.mkdtemp(prefix='lithiumtest')
+        self.cwd = os.getcwd()
+        os.chdir(self.tmpd)
+
+    def tearDown(self):
+        os.chdir(self.cwd)
+        shutil.rmtree(self.tmpd)
+
+    if sys.version_info.major == 2:
+
+        def assertRegex(self, *args, **kwds):
+            return self.assertRegexpMatches(*args, **kwds)
+
+        def assertRaisesRegex(self, *args, **kwds):
+            return self.assertRaisesRegexp(*args, **kwds)
+
+
+class DummyInteresting(object):
+    def init(self, conditionArgs):
+        pass
+    def interesting(self, conditionArgs, tempPrefix):
+        pass
+    def cleanup(self, conditionArgs):
+        pass
+
+class LithiumTests(TestCase):
+
+    def test_executable(self):
+        with self.assertRaisesRegex(SystemExit, "0"):
+            lithium.Lithium().main(["-h"])
+
+    def test_class(self):
+        l = lithium.Lithium()
+        with open("empty.txt", "w"):
+            pass
+        class Interesting(DummyInteresting):
+            init_called = False
+            interesting_called = False
+            cleanup_called = False
+            def init(sub, conditionArgs):
+                sub.init_called = True
+            def interesting(sub, conditionArgs, tempPrefix):
+                sub.interesting_called = True
+                return True
+            def cleanup(sub, conditionArgs):
+                sub.cleanup_called = True
+        inter = Interesting()
+        l.conditionScript = inter
+        l.conditionArgs = ["empty.txt"]
+        l.strategy = lithium.CheckOnly()
+        l.testcase = lithium.TestcaseLine()
+        l.testcase.readTestcase("empty.txt")
+        self.assertEqual(l.run(), 0)
+        self.assertTrue(inter.init_called)
+        self.assertTrue(inter.interesting_called)
+        self.assertTrue(inter.cleanup_called)
+
+    def test_arithmetic(self):
+        path = os.path.join(os.path.dirname(lithium.__file__), "examples", "arithmetic")
+        shutil.copyfile(os.path.join(path, "11.txt"), "11.txt")
+        result = lithium.Lithium().main([os.path.join(path, "product_divides.py"), "35", "11.txt"])
+        self.assertEqual(result, 0)
+        with open("11.txt") as f:
+            self.assertEqual(f.read(), "2\n\n# DDBEGIN\n5\n7\n# DDEND\n\n2\n")
+        shutil.copyfile(os.path.join(path, "11.txt"), "11.txt")
+        result = lithium.Lithium().main(["-c", os.path.join(path, "product_divides.py"), "35", "11.txt"])
+        self.assertEqual(result, 0)
+        with open("11.txt") as f:
+            self.assertEqual(f.read(), "2\n\n# DDBEGIN\n5\n7\n# DDEND\n\n2\n")
+
+
+class TestcaseTests(TestCase):
+
+    def test_line(self):
+        t = lithium.TestcaseLine()
+        with open("a.txt", "wb") as f:
+            f.write(b"hello")
+        t.readTestcase("a.txt")
+        os.unlink("a.txt")
+        self.assertFalse(os.path.isfile("a.txt"))
+        t.writeTestcase()
+        with open("a.txt", "rb") as f:
+            self.assertEqual(f.read(), b"hello")
+        self.assertEqual(t.filename, "a.txt")
+        self.assertEqual(t.extension, ".txt")
+        self.assertEqual(t.before, b"")
+        self.assertEqual(t.parts, [b"hello"])
+        self.assertEqual(t.after, b"")
+        t.writeTestcase("b.txt")
+        with open("b.txt", "rb") as f:
+            self.assertEqual(f.read(), b"hello")
+
+    def test_line_dd(self):
+        t = lithium.TestcaseLine()
+        with open("a.txt", "wb") as f:
+            f.write(b"pre\n")
+            f.write(b"DDBEGIN\n")
+            f.write(b"data\n")
+            f.write(b"2\n")
+            f.write(b"DDEND\n")
+            f.write(b"post\n")
+        t.readTestcase("a.txt")
+        self.assertEqual(t.before, b"pre\nDDBEGIN\n")
+        self.assertEqual(t.parts, [b"data\n", b"2\n"])
+        self.assertEqual(t.after, b"DDEND\npost\n")
+
+    def test_char_dd(self):
+        t = lithium.TestcaseChar()
+        with open("a.txt", "wb") as f:
+            f.write(b"pre\n")
+            f.write(b"DDBEGIN\n")
+            f.write(b"data\n")
+            f.write(b"2\n")
+            f.write(b"DDEND\n")
+            f.write(b"post\n")
+        t.readTestcase("a.txt")
+        self.assertEqual(t.before, b"pre\nDDBEGIN\n")
+        self.assertEqual(t.parts, [b"d", b"a", b"t", b"a", b"\n", b"2"])
+        self.assertEqual(t.after, b"\nDDEND\npost\n")
+
+    def test_symbol(self):
+        t = lithium.TestcaseSymbol()
+        with open("a.txt", "wb") as f:
+            f.write(b"pre\n")
+            f.write(b"DDBEGIN\n")
+            f.write(b"d{a}ta\n")
+            f.write(b"2\n")
+            f.write(b"DDEND\n")
+            f.write(b"post\n")
+        t.readTestcase("a.txt")
+        self.assertEqual(t.before, b"pre\nDDBEGIN\n")
+        self.assertEqual(t.parts, [b"d{", b"a", b"}ta\n", b"2\n"])
+        self.assertEqual(t.after, b"DDEND\npost\n")
+        with open("a.txt", "wb") as f:
+            f.write(b"pre\n")
+            f.write(b"DDBEGIN\n")
+            f.write(b"{data\n")
+            f.write(b"2}\n}")
+            f.write(b"DDEND\n")
+            f.write(b"post\n")
+        t.readTestcase("a.txt")
+        self.assertEqual(t.before, b"pre\nDDBEGIN\n")
+        self.assertEqual(t.parts, [b"{", b"data\n", b"2", b"}\n"])
+        self.assertEqual(t.after, b"}DDEND\npost\n")
+
+    def test_errors(self):
+        with open("a.txt", "w") as f:
+            f.write("DDEND\n")
+        t = lithium.TestcaseLine()
+        with self.assertRaisesRegex(lithium.LithiumError, r"^The testcase \(a\.txt\) has a line containing 'DDEND' without"):
+            t.readTestcase("a.txt")
+        with open("a.txt", "w") as f:
+            f.write("DDBEGIN DDEND\n")
+        with self.assertRaisesRegex(lithium.LithiumError, r"^The testcase \(a\.txt\) has a line containing 'DDEND' without"):
+            t.readTestcase("a.txt")
+        with open("a.txt", "w") as f:
+            f.write("DDEND DDBEGIN\n")
+        with self.assertRaisesRegex(lithium.LithiumError, r"^The testcase \(a\.txt\) has a line containing 'DDEND' without"):
+            t.readTestcase("a.txt")
+        with open("a.txt", "w") as f:
+            f.write("DDBEGIN\n")
+        with self.assertRaisesRegex(lithium.LithiumError, r"^The testcase \(a\.txt\) has a line containing 'DDBEGIN' but no"):
+            t.readTestcase("a.txt")
+


### PR DESCRIPTION
These commits organize Lithium into logical classes: Lithium, Strategy, and Testcase. This makes the data model explicit instead of using globals everywhere. It also makes testing far easier.

A basic set of tests are also included. Tests are passing in both python 2.7 and python 3.6 and cover 79% of lithium.py.

This should be completely compatible with existing interesting scripts, but I have only tested with the arithmetic example and domInteresting.py from DOMFuzz.