### PR TITLE
Remove support for Python 3.3

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,12 +3,10 @@ image:
 environment:
     matrix:
         - PYTHON: "C:\\Python27"
-        - PYTHON: "C:\\Python33"
         - PYTHON: "C:\\Python34"
         - PYTHON: "C:\\Python35"
         - PYTHON: "C:\\Python36"
         - PYTHON: "C:\\Python27-x64"
-        - PYTHON: "C:\\Python33-x64"
         - PYTHON: "C:\\Python34-x64"
         - PYTHON: "C:\\Python35-x64"
         - PYTHON: "C:\\Python36-x64"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ dist: trusty
 sudo: false
 language: python
 python:
-    - 2.7
-    - 3.3
-    - 3.4
-    - 3.5
-    - 3.6
-    - nightly
+    - "2.7"
+    - "3.3"
+    - "3.4"
+    - "3.5"
+    - "3.6"
+    - "nightly"
 before_install:
     - pip install --upgrade setuptools pip
     - pip install --upgrade virtualenv

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: python
 python:
     - "2.7"
-    - "3.3"
     - "3.4"
     - "3.5"
     - "3.6"


### PR DESCRIPTION
Python 3.3 is due to end-of-life [in less than 3 months](https://docs.python.org/devguide/#status-of-python-branches). There are [3.3-specific pylint import errors](https://github.com/MozillaSecurity/lithium/pull/24#issuecomment-314309741) that do not exist in 3.4+, so let's stop supporting/testing on 3.3.

Thus, current Python support versions will be: 2.7 or 3.4+

~~This relies on PR #24 and all its prior PR prerequisites.~~ - Updated to not rely on #24.