### PR TITLE
Follow-up fixes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,6 +2,10 @@
 # coding=utf-8
 # flake8: noqa
 # pylint: disable=missing-docstring
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from __future__ import absolute_import
 from .lithium.lithium import *  # pylint: disable=wildcard-import,unused-wildcard-import

--- a/__init__.py
+++ b/__init__.py
@@ -8,4 +8,5 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from __future__ import absolute_import
+
 from .lithium.lithium import *  # pylint: disable=wildcard-import,unused-wildcard-import

--- a/__main__.py
+++ b/__main__.py
@@ -7,6 +7,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from __future__ import absolute_import
+
 from .lithium.lithium import main
 
 main()

--- a/__main__.py
+++ b/__main__.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 # coding=utf-8
 # pylint: disable=missing-docstring
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from __future__ import absolute_import
 from .lithium.lithium import main

--- a/interestingness/crashes.py
+++ b/interestingness/crashes.py
@@ -12,9 +12,9 @@ from . import timedRun
 def parseOptions(arguments):
     parser = OptionParser()
     parser.disable_interspersed_args()
-    parser.add_option('-t', '--timeout', type='int', action='store', dest='condTimeout',
+    parser.add_option("-t", "--timeout", type="int", action="store", dest="condTimeout",
                       default=120,
-                      help='Optionally set the timeout. Defaults to "%default" seconds.')
+                      help="Optionally set the timeout. Defaults to '%default' seconds.")
 
     options, args = parser.parse_args(arguments)
 
@@ -27,7 +27,7 @@ def interesting(cliArgs, tempPrefix):
     runinfo = timedRun.timed_run(args, timeout, tempPrefix)
     timeString = " (%.3f seconds)" % runinfo.elapsedtime
     if runinfo.sta == timedRun.CRASHED:
-        print('Exit status: ' + runinfo.msg + timeString)
+        print("Exit status: " + runinfo.msg + timeString)
         return True
 
     print("[Uninteresting] It didn't crash." + timeString)

--- a/interestingness/crashes.py
+++ b/interestingness/crashes.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 # coding=utf-8
 # pylint: disable=invalid-name,missing-docstring
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from __future__ import absolute_import, print_function
 

--- a/interestingness/diffTest.py
+++ b/interestingness/diffTest.py
@@ -16,9 +16,9 @@ This can be used to isolate and minimize differential behaviour test cases.
 
 from __future__ import absolute_import, print_function
 
+import filecmp
 from optparse import OptionParser  # pylint: disable=deprecated-module
 
-import filecmp
 from . import timedRun
 
 

--- a/interestingness/diffTest.py
+++ b/interestingness/diffTest.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 # coding=utf-8
 # pylint: disable=invalid-name,missing-docstring
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 """
 This test minimizes a test case by comparing a single binary with different command line arguments.

--- a/interestingness/diffTest.py
+++ b/interestingness/diffTest.py
@@ -2,10 +2,10 @@
 # coding=utf-8
 # pylint: disable=invalid-name,missing-docstring
 
-'''
+"""
 This test minimizes a test case by comparing a single binary with different command line arguments.
 This can be used to isolate and minimize differential behaviour test cases.
-'''
+"""
 
 # This file came from nbp's GitHub PR #2 for adding new Lithium reduction strategies.
 #   https://github.com/MozillaSecurity/lithium/pull/2
@@ -21,15 +21,15 @@ from . import timedRun
 def parseOptions(arguments):
     parser = OptionParser()
     parser.disable_interspersed_args()
-    parser.add_option('-t', '--timeout', type='int', action='store', dest='condTimeout',
+    parser.add_option("-t", "--timeout", type="int", action="store", dest="condTimeout",
                       default=120,
-                      help='Optionally set the timeout. Defaults to "%default" seconds.')
-    parser.add_option('-a', '--a-arg', type='string', action='append', dest='aArgs',
+                      help="Optionally set the timeout. Defaults to '%default' seconds.")
+    parser.add_option("-a", "--a-arg", type="string", action="append", dest="aArgs",
                       default=[],
-                      help='Set of extra arguments given to first run.')
-    parser.add_option('-b', '--b-arg', type='string', action='append', dest='bArgs',
+                      help="Set of extra arguments given to first run.")
+    parser.add_option("-b", "--b-arg", type="string", action="append", dest="bArgs",
                       default=[],
-                      help='Set of extra arguments given to second run.')
+                      help="Set of extra arguments given to second run.")
 
     options, args = parser.parse_args(arguments)
 

--- a/interestingness/envVars.py
+++ b/interestingness/envVars.py
@@ -3,8 +3,8 @@
 # pylint: disable=invalid-name,missing-docstring
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this file,
-# You can obtain one at http://mozilla.org/MPL/2.0/.
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from __future__ import absolute_import, print_function
 

--- a/interestingness/envVars.py
+++ b/interestingness/envVars.py
@@ -12,22 +12,22 @@ import copy
 import os
 import platform
 
-isLinux = (platform.system() == 'Linux')
-isMac = (platform.system() == 'Darwin')
-isWin = (platform.system() == 'Windows')
+isLinux = (platform.system() == "Linux")
+isMac = (platform.system() == "Darwin")
+isWin = (platform.system() == "Windows")
 
-ENV_PATH_SEPARATOR = ';' if os.name == 'nt' else ':'
+ENV_PATH_SEPARATOR = ";" if os.name == "nt" else ":"
 
 
 def envWithPath(path, runningEnv=None):
     """Append the path to the appropriate library path on various platforms."""
     runningEnv = runningEnv or os.environ
     if isLinux:
-        libPath = 'LD_LIBRARY_PATH'
+        libPath = "LD_LIBRARY_PATH"
     elif isMac:
-        libPath = 'DYLD_LIBRARY_PATH'
+        libPath = "DYLD_LIBRARY_PATH"
     elif isWin:
-        libPath = 'PATH'
+        libPath = "PATH"
 
     env = copy.deepcopy(runningEnv)
     if libPath in env:
@@ -45,23 +45,23 @@ def findLlvmBinPath():
         # Assumes clang was installed through apt-get. Works with version 3.6.2,
         # assumed to work with clang 3.8.0.
         # Create a symlink at /usr/bin/llvm-symbolizer for: /usr/bin/llvm-symbolizer-3.8
-        if os.path.isfile('/usr/bin/llvm-symbolizer'):
-            return ''
+        if os.path.isfile("/usr/bin/llvm-symbolizer"):
+            return ""
 
-        print('WARNING: Please install clang via `apt-get install clang` if using Ubuntu.')
-        print('then create a symlink at /usr/bin/llvm-symbolizer for: /usr/bin/llvm-symbolizer-3.8.')
-        print('Try: `ln -s /usr/bin/llvm-symbolizer-3.8 /usr/bin/llvm-symbolizer`')
-        return ''
+        print("WARNING: Please install clang via `apt-get install clang` if using Ubuntu.")
+        print("then create a symlink at /usr/bin/llvm-symbolizer for: /usr/bin/llvm-symbolizer-3.8.")
+        print("Try: `ln -s /usr/bin/llvm-symbolizer-3.8 /usr/bin/llvm-symbolizer`")
+        return ""
 
     if isMac:
         # Assumes LLVM was installed through Homebrew. Works with at least version 3.6.2.
-        brewLLVMPath = '/usr/local/opt/llvm/bin'
+        brewLLVMPath = "/usr/local/opt/llvm/bin"
         if os.path.isdir(brewLLVMPath):
             return brewLLVMPath
 
-        print('WARNING: Please install llvm from Homebrew via `brew install llvm`.')
-        print('ASan stacks will not have symbols as Xcode does not install llvm-symbolizer.')
-        return ''
+        print("WARNING: Please install llvm from Homebrew via `brew install llvm`.")
+        print("ASan stacks will not have symbols as Xcode does not install llvm-symbolizer.")
+        return ""
 
     # https://developer.mozilla.org/en-US/docs/Building_Firefox_with_Address_Sanitizer#Manual_Build
     if isWin:

--- a/interestingness/fileIngredients.py
+++ b/interestingness/fileIngredients.py
@@ -3,8 +3,8 @@
 # pylint: disable=invalid-name,missing-docstring
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this file,
-# You can obtain one at http://mozilla.org/MPL/2.0/.
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from __future__ import absolute_import, print_function
 

--- a/interestingness/fileIngredients.py
+++ b/interestingness/fileIngredients.py
@@ -18,12 +18,12 @@ def fileContains(f, s, isRegex, vb=True):
 
 
 def fileContainsStr(f, s, verbose=True):
-    with open(f, 'rb') as g:
+    with open(f, "rb") as g:
         gContents = [l.strip() for l in g.read().splitlines() if l.strip()]
         for line in gContents:
             if line.find(s) != -1:
-                if verbose and s != '':
-                    print('[Found string in: "' + line.rstrip() + '"]', end=' ')
+                if verbose and s != "":
+                    print("[Found string in: '" + line.rstrip() + "']", end=" ")
                 return True
     return False
 
@@ -32,13 +32,13 @@ def fileContainsRegex(f, regex, verbose=True):
     # e.g. ~/fuzzing/lithium/lithium.py crashesat --timeout=30
     #       --regex '^#0\s*0x.* in\s*.*(?:\n|\r\n?)#1\s*' ./js --ion -n 735957.js
     # Note that putting "^" and "$" together is unlikely to work.
-    matchedStr = ''
+    matchedStr = ""
     found = False
-    with open(f, 'rb') as g:
+    with open(f, "rb") as g:
         foundRegex = regex.search(g.read())
         if foundRegex:
             matchedStr = foundRegex.group()
-            if verbose and matchedStr != '':
-                print('[Found string in: "' + matchedStr + '"]', end=' ')
+            if verbose and matchedStr != "":
+                print("[Found string in: '" + matchedStr + "']", end=" ")
             found = True
     return found, matchedStr

--- a/interestingness/hangs.py
+++ b/interestingness/hangs.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 # coding=utf-8
 # pylint: disable=invalid-name,missing-docstring
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from __future__ import absolute_import, print_function
 

--- a/interestingness/outputs.py
+++ b/interestingness/outputs.py
@@ -13,12 +13,12 @@ from . import timedRun
 def parseOptions(arguments):
     parser = OptionParser()
     parser.disable_interspersed_args()
-    parser.add_option('-t', '--timeout', type='int', action='store', dest='condTimeout',
+    parser.add_option("-t", "--timeout", type="int", action="store", dest="condTimeout",
                       default=120,
-                      help='Optionally set the timeout. Defaults to 120 seconds.')
-    parser.add_option('-r', '--regex', action='store_true', dest='useRegex',
+                      help="Optionally set the timeout. Defaults to 120 seconds.")
+    parser.add_option("-r", "--regex", action="store_true", dest="useRegex",
                       default=False,
-                      help='Allow search for regular expressions instead of strings.')
+                      help="Allow search for regular expressions instead of strings.")
     options, args = parser.parse_args(arguments)
 
     return options.condTimeout, options.useRegex, args

--- a/interestingness/outputs.py
+++ b/interestingness/outputs.py
@@ -10,8 +10,7 @@ from __future__ import absolute_import, print_function
 
 from optparse import OptionParser  # pylint: disable=deprecated-module
 
-from . import fileIngredients
-from . import timedRun
+from . import fileIngredients, timedRun
 
 
 def parseOptions(arguments):

--- a/interestingness/outputs.py
+++ b/interestingness/outputs.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 # coding=utf-8
 # pylint: disable=invalid-name,missing-docstring
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from __future__ import absolute_import, print_function
 

--- a/interestingness/range.py
+++ b/interestingness/range.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 # coding=utf-8
 # pylint: disable=invalid-name,missing-docstring
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 # Repeats an interestingness test a given number of times.
 # If "RANGENUM" is present, it is replaced in turn with each number in the range.

--- a/interestingness/range.py
+++ b/interestingness/range.py
@@ -1,32 +1,34 @@
 #!/usr/bin/env python
 # coding=utf-8
-# pylint: disable=invalid-name,missing-docstring
+# pylint: disable=invalid-name
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-# Repeats an interestingness test a given number of times.
-# If "RANGENUM" is present, it is replaced in turn with each number in the range.
-#
-# Use for:
-#
-# 1. Intermittent testcases.
-#
-#    Repeating the test can make the bug occur often enough for Lithium to make progress.
-#
-#     lithium.py range 1 20 crashes --timeout=3 ./js-dbg-32-mozilla-central-linux -m -n intermittent.js
-#
-# 2. Unstable testcases.
-#
-#    Varying a number in the test (using RANGENUM) may allow other parts of the testcase to be
-#    removed (Lithium), or may allow different versions of the shell to crash (autoBisect).
-#
-#    In the testcase:
-#      schedulegc(n);
-#
-#    On the command line:
-#      lithium.py range 1 50 crashes --timeout=3 ./js-dbg-32-mozilla-central-linux -e "n=RANGENUM;" 740654.js
+"""
+Repeats an interestingness test a given number of times.
+If "RANGENUM" is present, it is replaced in turn with each number in the range.
+
+Use for:
+
+1. Intermittent testcases.
+
+   Repeating the test can make the bug occur often enough for Lithium to make progress.
+
+    lithium.py range 1 20 crashes --timeout=3 ./js-dbg-32-mozilla-central-linux -m -n intermittent.js
+
+2. Unstable testcases.
+
+   Varying a number in the test (using RANGENUM) may allow other parts of the testcase to be
+   removed (Lithium), or may allow different versions of the shell to crash (autoBisect).
+
+   In the testcase:
+     schedulegc(n);
+
+   On the command line:
+     lithium.py range 1 50 crashes --timeout=3 ./js-dbg-32-mozilla-central-linux -e "n=RANGENUM;" 740654.js
+"""
 
 from __future__ import absolute_import, print_function
 
@@ -35,7 +37,7 @@ from optparse import OptionParser  # pylint: disable=deprecated-module
 from . import ximport
 
 
-def parseOptions(arguments):
+def parseOptions(arguments):  # pylint: disable=missing-docstring
     parser = OptionParser()
     parser.disable_interspersed_args()
     _options, args = parser.parse_args(arguments)
@@ -43,7 +45,7 @@ def parseOptions(arguments):
     return int(args[0]), int(args[1]), args[2:]  # args[0] is minLoopNum, args[1] maxLoopNum
 
 
-def interesting(cliArgs, tempPrefix):
+def interesting(cliArgs, tempPrefix):  # pylint: disable=missing-docstring
     (rangeMin, rangeMax, arguments) = parseOptions(cliArgs)
     conditionScript = ximport.importRelativeOrAbsolute(arguments[0])
     conditionArgs = arguments[1:]

--- a/interestingness/range.py
+++ b/interestingness/range.py
@@ -50,8 +50,8 @@ def interesting(cliArgs, tempPrefix):
     assert (rangeMax - rangeMin) >= 0
     for i in range(rangeMin, rangeMax + 1):
         # This doesn't do anything if RANGENUM is not found.
-        replacedConditionArgs = [s.replace('RANGENUM', str(i)) for s in conditionArgs]
-        print('Range number %d:' % i, end=' ')
+        replacedConditionArgs = [s.replace("RANGENUM", str(i)) for s in conditionArgs]
+        print("Range number %d:" % i, end=" ")
         if conditionScript.interesting(replacedConditionArgs, tempPrefix):
             return True
 

--- a/interestingness/timedRun.py
+++ b/interestingness/timedRun.py
@@ -48,16 +48,16 @@ def xpkill(p):
     except WindowsError:  # pylint: disable=undefined-variable
         if p.poll() == 0:
             try:
-                print('Trying to kill the process the first time...')
+                print("Trying to kill the process the first time...")
                 p.kill()  # Verify that the process is really killed.
             except WindowsError:  # pylint: disable=undefined-variable
                 if p.poll() == 0:
-                    print('Trying to kill the process the second time...')
+                    print("Trying to kill the process the second time...")
                     p.kill()  # Re-verify that the process is really killed.
 
 
 def makeEnv(binPath):
-    shellIsDeterministic = '-dm-' in binPath
+    shellIsDeterministic = "-dm-" in binPath
     # Total hack to make this not rely on queryBuildConfiguration in the funfuzz repository.
     # We need this so releng machines (which work off downloaded shells that are in build/dist/js),
     # do not compile LLVM.
@@ -65,10 +65,10 @@ def makeEnv(binPath):
         return None
 
     env = envVars.envWithPath(os.path.abspath(os.path.dirname(binPath)))
-    env['ASAN_OPTIONS'] = 'exitcode=' + str(ASAN_EXIT_CODE)
+    env["ASAN_OPTIONS"] = "exitcode=" + str(ASAN_EXIT_CODE)
     symbolizer_path = envVars.findLlvmBinPath()
     if symbolizer_path is not None:
-        env['ASAN_SYMBOLIZER_PATH'] = os.path.join(symbolizer_path, 'llvm-symbolizer')
+        env["ASAN_SYMBOLIZER_PATH"] = os.path.join(symbolizer_path, "llvm-symbolizer")
     return env
 
 
@@ -88,8 +88,8 @@ def timed_run(commandWithArgs,  # pylint: disable=too-many-branches,too-many-loc
     starttime = time.time()
 
     if useLogFiles:
-        childStdOut = open(logPrefix + "-out.txt", 'w')
-        childStdErr = open(logPrefix + "-err.txt", 'w')
+        childStdOut = open(logPrefix + "-out.txt", "w")
+        childStdErr = open(logPrefix + "-err.txt", "w")
 
     try:
         child = subprocess.Popen(
@@ -113,7 +113,7 @@ def timed_run(commandWithArgs,  # pylint: disable=too-many-branches,too-many-loc
         child.stdin.close()
 
     sta = NONE
-    msg = ''
+    msg = ""
 
     killed = False
 
@@ -129,9 +129,9 @@ def timed_run(commandWithArgs,  # pylint: disable=too-many-branches,too-many-loc
         elapsedtime = time.time() - starttime
         if rc is None:
             if elapsedtime > timeout and not killed:
-                if progname == 'gdb':
-                    raise Exception('Do not use this with gdb, because xpkill in timedRun will ' +
-                                    'kill gdb but leave the process within gdb still running')
+                if progname == "gdb":
+                    raise Exception("Do not use this with gdb, because xpkill in timedRun will "
+                                    "kill gdb but leave the process within gdb still running")
                 xpkill(child)
                 # but continue looping, because maybe kill takes a few seconds or maybe it's busy crashing!
                 killed = True
@@ -141,23 +141,23 @@ def timed_run(commandWithArgs,  # pylint: disable=too-many-branches,too-many-loc
             break
 
     if killed and (os.name != "posix" or rc == -signal.SIGKILL):  # pylint: disable=no-member
-        msg = 'TIMED OUT'
+        msg = "TIMED OUT"
         sta = TIMED_OUT
     elif rc == 0:
-        msg = 'NORMAL'
+        msg = "NORMAL"
         sta = NORMAL
     elif rc == ASAN_EXIT_CODE:
-        msg = 'CRASHED (Address Sanitizer fault)'
+        msg = "CRASHED (Address Sanitizer fault)"
         sta = CRASHED
     elif rc > 0:
-        msg = 'ABNORMAL exit code ' + str(rc)
+        msg = "ABNORMAL exit code " + str(rc)
         sta = ABNORMAL
     else:
         # rc < 0
         # The program was terminated by a signal, which usually indicates a crash.
         # Mac/Linux only!
         signum = -rc
-        msg = 'CRASHED signal %d (%s)' % (signum, getSignalName(signum, "Unknown signal"))
+        msg = "CRASHED signal %d (%s)" % (signum, getSignalName(signum, "Unknown signal"))
         sta = CRASHED
 
     if useLogFiles:

--- a/interestingness/timedRun.py
+++ b/interestingness/timedRun.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 # coding=utf-8
 # pylint: disable=invalid-name,missing-docstring
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from __future__ import absolute_import, print_function
 

--- a/interestingness/ximport.py
+++ b/interestingness/ximport.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 # coding=utf-8
 # pylint: disable=invalid-name,missing-docstring
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 # This lets you import an interestingness test given a full path, or given just a filename
 # (assuming it's in the current directory OR in the same directory as ximport)

--- a/interestingness/ximport.py
+++ b/interestingness/ximport.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python
 # coding=utf-8
-# pylint: disable=invalid-name,missing-docstring
+# pylint: disable=invalid-name
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-# This lets you import an interestingness test given a full path, or given just a filename
-# (assuming it's in the current directory OR in the same directory as ximport)
+"""
+This lets you import an interestingness test given a full path, or given just a filename.
+(assuming it's in the current directory OR in the same directory as ximport)
+"""
 
 from __future__ import absolute_import
 
@@ -18,7 +20,7 @@ import sys
 log = logging.getLogger("lithium")
 
 
-def importRelativeOrAbsolute(f):
+def importRelativeOrAbsolute(f):  # pylint: disable=missing-docstring
     # maybe there's a way to do this more sanely with the |imp| module...
     if f.endswith(".py"):
         f = f[:-3]

--- a/lithium/doc/using.html
+++ b/lithium/doc/using.html
@@ -43,8 +43,8 @@
 <dt>--char (-c)<dt>
 <dd>By default, Lithium treats lines as atomic units.  This is great if each line is a JavaScript statement, but sometimes you want to go further.  Use this option to tell Lithium to treat the file as a sequence of characters instead of a sequence of lines.</dd>
 
-<dt>--strategy=[minimize, check-only]</dt>
-<dd>"minimize" is the default, the algorithm described above. "check-only" tries to run Lithium to determine interestingness, without reduction.</dd>
+<dt>--strategy=[check-only,minimize,minimize-balanced,replace-properties-by-globals,replace-arguments-by-globals,minimize-around]</dt>
+<dd>"minimize" is the default, the algorithm described above. "check-only" tries to run Lithium to determine interestingness, without reduction. For the other strategies, check out <a href="https://github.com/MozillaSecurity/lithium/pull/2">this GitHub PR</a>.</dd>
 
 <dt>--repeat=[always, last, never].</dt>
 <dd>By default, Lithium only repeats at the same chunk size if it just finished the last round (e.g. chunk size 1).  You can use --repeat=always to tell it to repeat any chunk size if something was removed during the round, which can be useful for non-deterministic testcases or non-monotonic situations.  You can use --repeat=never to tell it to exit immediately after a single round at the last chunk size, which can save a little time at the risk of leaving a little bit extra in the file.</dd>
@@ -66,18 +66,17 @@
 
 <h3>Requirements</h3>
 
-<p>Lithium is written in <a href="http://www.python.org/">Python</a> and requires Python 2.4.  (It uses <a href="http://www.python.org/dev/peps/pep-0289/">generator expressions</a> and the <a href="http://docs.python.org/lib/module-subprocess.html">subprocess</a> module, both of which were introduced with Python 2.4)
+<p>Lithium is written in <a href="http://www.python.org/">Python</a> and requires Python 2.7 or 3.4+.</p>
 
 <p>Various versions of Lithium have been used successfully with:</p>
 
 <ul>
-<li>Mac 10.4.10 + Python 2.4.3</li>
-<li>Mac 10.4.10 + Python 2.5.1</li>
-<li>Mac 10.5.7 + Python 2.5.1</li>
-<li>Windows XP + the <a href="http://www.cygwin.com/">Cygwin</a> version of Python 2.5, under both DOS and Bash</li>
+<li>Windows 7 / 10 via <a href="https://wiki.mozilla.org/MozillaBuild">MozillaBuild 2.2.0</a> and up. This comes with 2.7.</li>
+<li>macOS Sierra 10.12 + Python 2.7</li>
+<li>Ubuntu Linux 14.04 / 16.04 + Python 2.7 / Python 3.4+</li>
 </ul>
 
-<p>It is known to <em>not</em> work well in MSYS, an alternative to Cygwin.  I've seen Lithium sorta work in MSYS after adding add ", shell=True" to the call to "subprocess.call" removing the "./" before the test filename, but even then it was buggy.  I recommend using Cygwin's Python instead.</p>
+<p>It may or may not work in Windows XP/Vista anymore.</p>
 
 
 <h3>Credits</h3>
@@ -86,6 +85,7 @@
 <li><a href="algorithm.html">Lithium's testcase reduction algorithm</a> is a modified version of the "ddmin" algorithm in Andreas Zeller's paper, <a href="http://www.st.cs.uni-sb.de/papers/tse2002/">Simplifying and Isolating Failure-Inducing Input</a>.</li>
 <li>The idea of using an external "interestingness test" program came from <a href="http://delta.tigris.org/">Delta</a>, a similar tool that's <a href="http://gcc.gnu.org/wiki/A_guide_to_testcase_reduction">used in clever ways by the GCC project</a>.</li>
 <li>ntr.py, used by many of the "interestingness test" scripts that come with Lithium, is based on <a href="http://bclary.com/log/2007/03/07/timed_run">timed_run.py</a>, which was written by <a href="http://coop.deadsquid.com/">Chris Cooper</a> and <a href="http://bclary.com/">Bob Clary</a>.</li>
+<li>The code was significantly cleaned up and modernized by Jesse Schwartzentruber and Gary Kwong in mid-2017.</li>
 </ul>
 
 </body>

--- a/lithium/examples/arithmetic/product_divides.py
+++ b/lithium/examples/arithmetic/product_divides.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
 # coding=utf-8
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 """
 Interesting if the product of the numbers in the file divides the argument.
 

--- a/lithium/lithium.py
+++ b/lithium/lithium.py
@@ -15,7 +15,6 @@ import re
 import sys
 import time
 
-
 log = logging.getLogger("lithium")
 
 

--- a/lithium/lithium.py
+++ b/lithium/lithium.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 # coding=utf-8
 # pylint: disable=invalid-name,missing-docstring,too-many-lines,too-many-statements
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from __future__ import absolute_import
 

--- a/lithium/tests.py
+++ b/lithium/tests.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 # coding=utf-8
 # pylint: disable=invalid-name,missing-docstring,too-few-public-methods
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from __future__ import absolute_import
 

--- a/lithium/tests.py
+++ b/lithium/tests.py
@@ -20,7 +20,6 @@ import unittest
 
 from . import lithium
 
-
 log = logging.getLogger("lithium_test")
 logging.basicConfig(level=logging.DEBUG)
 

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,10 @@
 # coding=utf-8
 # flake8: noqa
 # pylint: disable=missing-docstring
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from __future__ import absolute_import
 


### PR DESCRIPTION
* Conversions for all remaining strings to use double quotes (`"`) instead of single quotes (`'`).
* Adds proper MPL2 license notice blocks.
* Updates antiquated using.html and gets README.md to link to it as a start.
* Whitespace changes, import line rearrange.
* Some files already have file header comments, so convert them to docstrings as a start.