### PR TITLE
Revert "Fix linter import-related issues by moving entirely to absolu…

### DIFF
--- a/interestingness/crashes.py
+++ b/interestingness/crashes.py
@@ -6,11 +6,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import, print_function
-
+from __future__ import print_function
 from optparse import OptionParser  # pylint: disable=deprecated-module
 
-from . import timedRun
+import timedRun  # pylint: disable=relative-import
 
 
 def parseOptions(arguments):

--- a/interestingness/diffTest.py
+++ b/interestingness/diffTest.py
@@ -14,12 +14,12 @@ This can be used to isolate and minimize differential behaviour test cases.
 # This file came from nbp's GitHub PR #2 for adding new Lithium reduction strategies.
 #   https://github.com/MozillaSecurity/lithium/pull/2
 
-from __future__ import absolute_import, print_function
+from __future__ import print_function
 
 import filecmp
 from optparse import OptionParser  # pylint: disable=deprecated-module
 
-from . import timedRun
+import timedRun  # pylint: disable=relative-import
 
 
 def parseOptions(arguments):

--- a/interestingness/envVars.py
+++ b/interestingness/envVars.py
@@ -6,8 +6,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import, print_function
-
+from __future__ import print_function
 import copy
 import os
 import platform

--- a/interestingness/fileIngredients.py
+++ b/interestingness/fileIngredients.py
@@ -6,8 +6,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import, print_function
-
+from __future__ import print_function
 import re
 
 

--- a/interestingness/hangs.py
+++ b/interestingness/hangs.py
@@ -6,9 +6,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import, print_function
+from __future__ import print_function
 
-from . import timedRun
+import timedRun  # pylint: disable=relative-import
 
 
 def interesting(args, tempPrefix):

--- a/interestingness/outputs.py
+++ b/interestingness/outputs.py
@@ -6,11 +6,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import, print_function
+from __future__ import print_function
 
 from optparse import OptionParser  # pylint: disable=deprecated-module
 
-from . import fileIngredients, timedRun
+import fileIngredients  # pylint: disable=relative-import
+import timedRun  # pylint: disable=relative-import
 
 
 def parseOptions(arguments):

--- a/interestingness/range.py
+++ b/interestingness/range.py
@@ -30,11 +30,16 @@ Use for:
      lithium.py range 1 50 crashes --timeout=3 ./js-dbg-32-mozilla-central-linux -e "n=RANGENUM;" 740654.js
 """
 
-from __future__ import absolute_import, print_function
+from __future__ import print_function
 
+import os
+import sys
 from optparse import OptionParser  # pylint: disable=deprecated-module
 
-from . import ximport
+path0 = os.path.dirname(os.path.abspath(__file__))
+path1 = os.path.abspath(os.path.join(path0, os.pardir, 'util'))
+sys.path.append(path1)
+import ximport  # noqa  pylint: disable=relative-import,wrong-import-position
 
 
 def parseOptions(arguments):  # pylint: disable=missing-docstring

--- a/interestingness/timedRun.py
+++ b/interestingness/timedRun.py
@@ -6,7 +6,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import, print_function
+from __future__ import print_function
 
 import os
 import signal
@@ -14,7 +14,10 @@ import subprocess
 import sys
 import time
 
-from . import envVars
+path0 = os.path.dirname(os.path.abspath(__file__))
+path1 = os.path.abspath(os.path.join(path0, os.pardir, 'interestingness'))
+sys.path.append(path1)
+import envVars  # noqa  pylint: disable=relative-import,wrong-import-position
 
 ASAN_EXIT_CODE = 77
 

--- a/interestingness/ximport.py
+++ b/interestingness/ximport.py
@@ -11,8 +11,6 @@ This lets you import an interestingness test given a full path, or given just a 
 (assuming it's in the current directory OR in the same directory as ximport)
 """
 
-from __future__ import absolute_import
-
 import logging
 import os
 import sys

--- a/lithium/examples/arithmetic/product_divides.py
+++ b/lithium/examples/arithmetic/product_divides.py
@@ -11,8 +11,6 @@ Interesting if the product of the numbers in the file divides the argument.
 e.g. lithium product_divides 35 11.txt
 """
 
-from __future__ import absolute_import
-
 import sys
 
 

--- a/lithium/lithium.py
+++ b/lithium/lithium.py
@@ -6,8 +6,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
-
 import argparse
 import logging
 import os

--- a/lithium/tests.py
+++ b/lithium/tests.py
@@ -6,8 +6,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
-
 import collections
 import logging
 import math
@@ -18,7 +16,7 @@ import sys
 import tempfile
 import unittest
 
-from . import lithium
+import lithium  # pylint: disable=relative-import
 
 log = logging.getLogger("lithium_test")
 logging.basicConfig(level=logging.DEBUG)

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
-
 from setuptools import setup
 
 if __name__ == "__main__":


### PR DESCRIPTION
…te_import", then rebased.

This reverts commit 713dfe0d8c916b02a52f521a496ae67a1ff6399e, then rebased to master.

We encountered some problems importing lithium as a library module via pip local install, then using the modules in interestingness, so this PR reverts the shift to absolute_import until we figure out the cause.