### PR TITLE
Add more pylint checks and extensions

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -7,7 +7,8 @@ jobs=2
 # usually to register additional checkers.
 #
 # Whole list retrieved on 2017-07-28 from: https://pylint.readthedocs.io/en/latest/technical_reference/extensions.html
-load-plugins=pylint.extensions.bad_builtin,pylint.extensions.check_elif,pylint.extensions.comparetozero,pylint.extensions.docparams,pylint.extensions.docstyle,pylint.extensions.emptystring,pylint.extensions.mccabe,pylint.extensions.overlapping_exceptions,pylint.extensions.redefined_variable_type
+# Remaining disabled: pylint.extensions.comparetozero,pylint.extensions.emptystring
+load-plugins=pylint.extensions.bad_builtin,pylint.extensions.check_elif,pylint.extensions.docparams,pylint.extensions.docstyle,pylint.extensions.mccabe,pylint.extensions.overlapping_exceptions,pylint.extensions.redefined_variable_type
 accept-no-param-doc=no
 accept-no-raise-doc=no
 accept-no-return-doc=no
@@ -24,13 +25,13 @@ accept-no-yields-doc=no
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=locally-disabled,no-absolute-import,suppressed-message
+disable=locally-disabled,no-absolute-import,suppressed-message,useless-suppression
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once). See also the "--disable" option for examples.
-enable=apply-builtin,backtick,bad-inline-option,bad-python3-import,basestring-builtin,buffer-builtin,cmp-builtin,cmp-method,coerce-builtin,coerce-method,delslice-method,deprecated-pragma,deprecated-str-translate-call,deprecated-string-function,dict-iter-method,dict-view-method,div-method,eq-without-hash,exception-message-attribute,execfile-builtin,file-builtin,file-ignored,filter-builtin-not-iterating,getslice-method,hex-method,idiv-method,import-star-module-level,indexing-exception,input-builtin,intern-builtin,invalid-str-codec,locally-enabled,long-builtin,long-suffix,map-builtin-not-iterating,metaclass-assignment,next-method-called,nonzero-method,oct-method,old-division,old-ne-operator,old-octal-literal,old-raise-syntax,parameter-unpacking,print-statement,raising-string,range-builtin-not-iterating,raw-checker-failed,raw_input-builtin,rdiv-method,reduce-builtin,reload-builtin,round-builtin,setslice-method,standarderror-builtin,sys-max-int,unichr-builtin,unicode-builtin,unpacking-in-except,useless-suppression,using-cmp-argument,xrange-builtin,zip-builtin-not-iterating
+enable=apply-builtin,backtick,bad-inline-option,bad-python3-import,basestring-builtin,buffer-builtin,cmp-builtin,cmp-method,coerce-builtin,coerce-method,delslice-method,deprecated-pragma,deprecated-str-translate-call,deprecated-string-function,dict-iter-method,dict-view-method,div-method,eq-without-hash,exception-message-attribute,execfile-builtin,file-builtin,file-ignored,filter-builtin-not-iterating,getslice-method,hex-method,idiv-method,import-star-module-level,indexing-exception,input-builtin,intern-builtin,invalid-str-codec,locally-enabled,long-builtin,long-suffix,map-builtin-not-iterating,metaclass-assignment,next-method-called,nonzero-method,oct-method,old-division,old-ne-operator,old-octal-literal,old-raise-syntax,parameter-unpacking,print-statement,raising-string,range-builtin-not-iterating,raw-checker-failed,raw_input-builtin,rdiv-method,reduce-builtin,reload-builtin,round-builtin,setslice-method,standarderror-builtin,sys-max-int,unichr-builtin,unicode-builtin,unpacking-in-except,using-cmp-argument,xrange-builtin,zip-builtin-not-iterating
 
 [FORMAT]
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -3,6 +3,35 @@
 # Use multiple processes to speed up Pylint.
 jobs=2
 
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+#
+# Whole list retrieved on 2017-07-28 from: https://pylint.readthedocs.io/en/latest/technical_reference/extensions.html
+load-plugins=pylint.extensions.bad_builtin,pylint.extensions.check_elif,pylint.extensions.comparetozero,pylint.extensions.docparams,pylint.extensions.docstyle,pylint.extensions.emptystring,pylint.extensions.mccabe,pylint.extensions.overlapping_exceptions,pylint.extensions.redefined_variable_type
+accept-no-param-doc=no
+accept-no-raise-doc=no
+accept-no-return-doc=no
+accept-no-yields-doc=no
+
+[MESSAGES CONTROL]
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=locally-disabled,no-absolute-import,suppressed-message
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=apply-builtin,backtick,bad-inline-option,bad-python3-import,basestring-builtin,buffer-builtin,cmp-builtin,cmp-method,coerce-builtin,coerce-method,delslice-method,deprecated-pragma,deprecated-str-translate-call,deprecated-string-function,dict-iter-method,dict-view-method,div-method,eq-without-hash,exception-message-attribute,execfile-builtin,file-builtin,file-ignored,filter-builtin-not-iterating,getslice-method,hex-method,idiv-method,import-star-module-level,indexing-exception,input-builtin,intern-builtin,invalid-str-codec,locally-enabled,long-builtin,long-suffix,map-builtin-not-iterating,metaclass-assignment,next-method-called,nonzero-method,oct-method,old-division,old-ne-operator,old-octal-literal,old-raise-syntax,parameter-unpacking,print-statement,raising-string,range-builtin-not-iterating,raw-checker-failed,raw_input-builtin,rdiv-method,reduce-builtin,reload-builtin,round-builtin,setslice-method,standarderror-builtin,sys-max-int,unichr-builtin,unicode-builtin,unpacking-in-except,useless-suppression,using-cmp-argument,xrange-builtin,zip-builtin-not-iterating
+
 [FORMAT]
 
 # Maximum number of characters on a single line.

--- a/interestingness/crashes.py
+++ b/interestingness/crashes.py
@@ -8,7 +8,7 @@
 
 from __future__ import print_function
 
-import optparse  # pylint: disable=deprecated-module,useless-suppression
+import optparse  # pylint: disable=deprecated-module
 
 import timedRun  # pylint: disable=relative-import,useless-suppression
 

--- a/interestingness/crashes.py
+++ b/interestingness/crashes.py
@@ -10,7 +10,7 @@ from __future__ import print_function
 
 import optparse  # pylint: disable=deprecated-module
 
-import timedRun  # pylint: disable=relative-import,useless-suppression
+import timedRun  # pylint: disable=relative-import
 
 
 def parseOptions(arguments):

--- a/interestingness/crashes.py
+++ b/interestingness/crashes.py
@@ -9,6 +9,7 @@
 from __future__ import print_function
 from optparse import OptionParser  # pylint: disable=deprecated-module
 
+
 import timedRun  # pylint: disable=relative-import
 
 

--- a/interestingness/crashes.py
+++ b/interestingness/crashes.py
@@ -8,7 +8,7 @@
 
 from __future__ import print_function
 
-import optparse  # pylint: disable=deprecated-module
+import optparse  # pylint: disable=deprecated-module,useless-suppression
 
 import timedRun  # pylint: disable=relative-import,useless-suppression
 

--- a/interestingness/crashes.py
+++ b/interestingness/crashes.py
@@ -7,14 +7,14 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from __future__ import print_function
-from optparse import OptionParser  # pylint: disable=deprecated-module
 
+import optparse  # pylint: disable=deprecated-module
 
 import timedRun  # pylint: disable=relative-import
 
 
 def parseOptions(arguments):
-    parser = OptionParser()
+    parser = optparse.OptionParser()
     parser.disable_interspersed_args()
     parser.add_option("-t", "--timeout", type="int", action="store", dest="condTimeout",
                       default=120,

--- a/interestingness/crashes.py
+++ b/interestingness/crashes.py
@@ -10,7 +10,7 @@ from __future__ import print_function
 
 import optparse  # pylint: disable=deprecated-module
 
-import timedRun  # pylint: disable=relative-import
+import timedRun  # pylint: disable=relative-import,useless-suppression
 
 
 def parseOptions(arguments):

--- a/interestingness/crashes.py
+++ b/interestingness/crashes.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-# pylint: disable=invalid-name,missing-docstring
+# pylint: disable=invalid-name,missing-docstring,missing-return-doc,missing-return-type-doc
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/interestingness/diffTest.py
+++ b/interestingness/diffTest.py
@@ -16,7 +16,7 @@ This can be used to isolate and minimize differential behaviour test cases.
 from __future__ import print_function
 
 import filecmp
-import optparse  # pylint: disable=deprecated-module
+import optparse  # pylint: disable=deprecated-module,useless-suppression
 
 import timedRun  # pylint: disable=relative-import,useless-suppression
 

--- a/interestingness/diffTest.py
+++ b/interestingness/diffTest.py
@@ -16,7 +16,7 @@ This can be used to isolate and minimize differential behaviour test cases.
 from __future__ import print_function
 
 import filecmp
-import optparse  # pylint: disable=deprecated-module,useless-suppression
+import optparse  # pylint: disable=deprecated-module
 
 import timedRun  # pylint: disable=relative-import,useless-suppression
 

--- a/interestingness/diffTest.py
+++ b/interestingness/diffTest.py
@@ -16,13 +16,13 @@ This can be used to isolate and minimize differential behaviour test cases.
 from __future__ import print_function
 
 import filecmp
-from optparse import OptionParser  # pylint: disable=deprecated-module
+import optparse  # pylint: disable=deprecated-module
 
 import timedRun  # pylint: disable=relative-import
 
 
 def parseOptions(arguments):
-    parser = OptionParser()
+    parser = optparse.OptionParser()
     parser.disable_interspersed_args()
     parser.add_option("-t", "--timeout", type="int", action="store", dest="condTimeout",
                       default=120,

--- a/interestingness/diffTest.py
+++ b/interestingness/diffTest.py
@@ -18,7 +18,7 @@ from __future__ import print_function
 import filecmp
 import optparse  # pylint: disable=deprecated-module
 
-import timedRun  # pylint: disable=relative-import
+import timedRun  # pylint: disable=relative-import,useless-suppression
 
 
 def parseOptions(arguments):

--- a/interestingness/diffTest.py
+++ b/interestingness/diffTest.py
@@ -18,7 +18,7 @@ from __future__ import print_function
 import filecmp
 import optparse  # pylint: disable=deprecated-module
 
-import timedRun  # pylint: disable=relative-import,useless-suppression
+import timedRun  # pylint: disable=relative-import
 
 
 def parseOptions(arguments):

--- a/interestingness/diffTest.py
+++ b/interestingness/diffTest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-# pylint: disable=invalid-name,missing-docstring
+# pylint: disable=invalid-name,missing-docstring,missing-return-doc,missing-return-type-doc
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/interestingness/diffTest.py
+++ b/interestingness/diffTest.py
@@ -6,8 +6,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-"""
-This test minimizes a test case by comparing a single binary with different command line arguments.
+"""This test minimizes a test case by comparing a single binary with different command line arguments.
 This can be used to isolate and minimize differential behaviour test cases.
 """
 

--- a/interestingness/envVars.py
+++ b/interestingness/envVars.py
@@ -7,6 +7,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from __future__ import print_function
+
 import copy
 import os
 import platform

--- a/interestingness/envVars.py
+++ b/interestingness/envVars.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # coding=utf-8
-# pylint: disable=invalid-name,missing-docstring
+# pylint: disable=invalid-name,missing-docstring,missing-param-doc,missing-return-doc,missing-return-type-doc
+# pylint: disable=missing-type-doc
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/interestingness/fileIngredients.py
+++ b/interestingness/fileIngredients.py
@@ -7,6 +7,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from __future__ import print_function
+
 import re
 
 

--- a/interestingness/fileIngredients.py
+++ b/interestingness/fileIngredients.py
@@ -22,7 +22,7 @@ def fileContainsStr(f, s, verbose=True):
         gContents = [l.strip() for l in g.read().splitlines() if l.strip()]
         for line in gContents:
             if line.find(s) != -1:
-                if verbose and s != "":
+                if verbose and s:
                     print("[Found string in: '" + line.rstrip() + "']", end=" ")
                 return True
     return False
@@ -38,7 +38,7 @@ def fileContainsRegex(f, regex, verbose=True):
         foundRegex = regex.search(g.read())
         if foundRegex:
             matchedStr = foundRegex.group()
-            if verbose and matchedStr != "":
+            if verbose and matchedStr:
                 print("[Found string in: '" + matchedStr + "']", end=" ")
             found = True
     return found, matchedStr

--- a/interestingness/fileIngredients.py
+++ b/interestingness/fileIngredients.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-# pylint: disable=invalid-name,missing-docstring
+# pylint: disable=invalid-name,missing-docstring,missing-return-doc,missing-return-type-doc
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/interestingness/fileIngredients.py
+++ b/interestingness/fileIngredients.py
@@ -22,7 +22,7 @@ def fileContainsStr(f, s, verbose=True):
         gContents = [l.strip() for l in g.read().splitlines() if l.strip()]
         for line in gContents:
             if line.find(s) != -1:
-                if verbose and s:
+                if verbose and s != "":
                     print("[Found string in: '" + line.rstrip() + "']", end=" ")
                 return True
     return False
@@ -38,7 +38,7 @@ def fileContainsRegex(f, regex, verbose=True):
         foundRegex = regex.search(g.read())
         if foundRegex:
             matchedStr = foundRegex.group()
-            if verbose and matchedStr:
+            if verbose and matchedStr != "":
                 print("[Found string in: '" + matchedStr + "']", end=" ")
             found = True
     return found, matchedStr

--- a/interestingness/hangs.py
+++ b/interestingness/hangs.py
@@ -8,7 +8,7 @@
 
 from __future__ import print_function
 
-import timedRun  # pylint: disable=relative-import
+import timedRun  # pylint: disable=relative-import,useless-suppression
 
 
 def interesting(args, tempPrefix):

--- a/interestingness/hangs.py
+++ b/interestingness/hangs.py
@@ -8,7 +8,7 @@
 
 from __future__ import print_function
 
-import timedRun  # pylint: disable=relative-import,useless-suppression
+import timedRun  # pylint: disable=relative-import
 
 
 def interesting(args, tempPrefix):

--- a/interestingness/hangs.py
+++ b/interestingness/hangs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-# pylint: disable=invalid-name,missing-docstring
+# pylint: disable=invalid-name,missing-docstring,missing-return-doc,missing-return-type-doc
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/interestingness/outputs.py
+++ b/interestingness/outputs.py
@@ -10,8 +10,8 @@ from __future__ import print_function
 
 import optparse  # pylint: disable=deprecated-module
 
-import fileIngredients  # pylint: disable=relative-import
-import timedRun  # pylint: disable=relative-import
+import fileIngredients  # pylint: disable=relative-import,useless-suppression
+import timedRun  # pylint: disable=relative-import,useless-suppression
 
 
 def parseOptions(arguments):

--- a/interestingness/outputs.py
+++ b/interestingness/outputs.py
@@ -8,7 +8,7 @@
 
 from __future__ import print_function
 
-import optparse  # pylint: disable=deprecated-module,useless-suppression
+import optparse  # pylint: disable=deprecated-module
 
 import fileIngredients  # pylint: disable=relative-import,useless-suppression
 import timedRun  # pylint: disable=relative-import,useless-suppression

--- a/interestingness/outputs.py
+++ b/interestingness/outputs.py
@@ -8,7 +8,7 @@
 
 from __future__ import print_function
 
-import optparse  # pylint: disable=deprecated-module
+import optparse  # pylint: disable=deprecated-module,useless-suppression
 
 import fileIngredients  # pylint: disable=relative-import,useless-suppression
 import timedRun  # pylint: disable=relative-import,useless-suppression

--- a/interestingness/outputs.py
+++ b/interestingness/outputs.py
@@ -8,14 +8,14 @@
 
 from __future__ import print_function
 
-from optparse import OptionParser  # pylint: disable=deprecated-module
+import optparse  # pylint: disable=deprecated-module
 
 import fileIngredients  # pylint: disable=relative-import
 import timedRun  # pylint: disable=relative-import
 
 
 def parseOptions(arguments):
-    parser = OptionParser()
+    parser = optparse.OptionParser()
     parser.disable_interspersed_args()
     parser.add_option("-t", "--timeout", type="int", action="store", dest="condTimeout",
                       default=120,

--- a/interestingness/outputs.py
+++ b/interestingness/outputs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-# pylint: disable=invalid-name,missing-docstring
+# pylint: disable=invalid-name,missing-docstring,missing-return-doc,missing-return-type-doc
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/interestingness/outputs.py
+++ b/interestingness/outputs.py
@@ -10,8 +10,8 @@ from __future__ import print_function
 
 import optparse  # pylint: disable=deprecated-module
 
-import fileIngredients  # pylint: disable=relative-import,useless-suppression
-import timedRun  # pylint: disable=relative-import,useless-suppression
+import fileIngredients  # pylint: disable=relative-import
+import timedRun  # pylint: disable=relative-import
 
 
 def parseOptions(arguments):

--- a/interestingness/range.py
+++ b/interestingness/range.py
@@ -31,7 +31,7 @@ Use for:
 
 from __future__ import print_function
 
-import optparse  # pylint: disable=deprecated-module,useless-suppression
+import optparse  # pylint: disable=deprecated-module
 import os
 import sys
 

--- a/interestingness/range.py
+++ b/interestingness/range.py
@@ -31,9 +31,9 @@ Use for:
 
 from __future__ import print_function
 
+import optparse  # pylint: disable=deprecated-module
 import os
 import sys
-from optparse import OptionParser  # pylint: disable=deprecated-module
 
 path0 = os.path.dirname(os.path.abspath(__file__))
 path1 = os.path.abspath(os.path.join(path0, os.pardir, 'util'))
@@ -42,7 +42,7 @@ import ximport  # noqa  pylint: disable=relative-import,wrong-import-position
 
 
 def parseOptions(arguments):  # pylint: disable=missing-docstring
-    parser = OptionParser()
+    parser = optparse.OptionParser()
     parser.disable_interspersed_args()
     _options, args = parser.parse_args(arguments)
 

--- a/interestingness/range.py
+++ b/interestingness/range.py
@@ -38,7 +38,7 @@ import sys
 path0 = os.path.dirname(os.path.abspath(__file__))
 path1 = os.path.abspath(os.path.join(path0, os.pardir, 'util'))
 sys.path.append(path1)
-import ximport  # noqa  pylint: disable=relative-import,useless-suppression,wrong-import-position
+import ximport  # noqa  pylint: disable=relative-import,wrong-import-position
 
 
 def parseOptions(arguments):  # pylint: disable=missing-docstring

--- a/interestingness/range.py
+++ b/interestingness/range.py
@@ -38,7 +38,7 @@ import sys
 path0 = os.path.dirname(os.path.abspath(__file__))
 path1 = os.path.abspath(os.path.join(path0, os.pardir, 'util'))
 sys.path.append(path1)
-import ximport  # noqa  pylint: disable=relative-import,wrong-import-position
+import ximport  # noqa  pylint: disable=relative-import,useless-suppression,wrong-import-position
 
 
 def parseOptions(arguments):  # pylint: disable=missing-docstring

--- a/interestingness/range.py
+++ b/interestingness/range.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name,missing-return-doc,missing-return-type-doc
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/interestingness/range.py
+++ b/interestingness/range.py
@@ -31,7 +31,7 @@ Use for:
 
 from __future__ import print_function
 
-import optparse  # pylint: disable=deprecated-module
+import optparse  # pylint: disable=deprecated-module,useless-suppression
 import os
 import sys
 

--- a/interestingness/range.py
+++ b/interestingness/range.py
@@ -6,8 +6,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-"""
-Repeats an interestingness test a given number of times.
+"""Repeats an interestingness test a given number of times.
 If "RANGENUM" is present, it is replaced in turn with each number in the range.
 
 Use for:

--- a/interestingness/timedRun.py
+++ b/interestingness/timedRun.py
@@ -18,7 +18,7 @@ import time
 path0 = os.path.dirname(os.path.abspath(__file__))
 path1 = os.path.abspath(os.path.join(path0, os.pardir, 'interestingness'))
 sys.path.append(path1)
-import envVars  # noqa  pylint: disable=relative-import,useless-suppression,wrong-import-position
+import envVars  # noqa  pylint: disable=relative-import,wrong-import-position
 
 ASAN_EXIT_CODE = 77
 
@@ -148,7 +148,7 @@ def timed_run(commandWithArgs,  # pylint: disable=too-complex,too-many-branches,
         else:
             break
 
-    if killed and (os.name != "posix" or rc == -signal.SIGKILL):  # pylint: disable=no-member,useless-suppression
+    if killed and (os.name != "posix" or rc == -signal.SIGKILL):  # pylint: disable=no-member
         msg = "TIMED OUT"
         sta = TIMED_OUT
     elif not rc:

--- a/interestingness/timedRun.py
+++ b/interestingness/timedRun.py
@@ -80,7 +80,7 @@ def makeEnv(binPath):
     return env
 
 
-def timed_run(commandWithArgs,  # pylint: disable=too-many-branches,too-many-locals,too-many-statements
+def timed_run(commandWithArgs,  # pylint: disable=too-complex,too-many-branches,too-many-locals,too-many-statements
               timeout, logPrefix, inp=None, preexec_fn=None):
     """If logPrefix is None, uses pipes instead of files for all output."""
     if not isinstance(commandWithArgs, list):

--- a/interestingness/timedRun.py
+++ b/interestingness/timedRun.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # coding=utf-8
-# pylint: disable=invalid-name,missing-docstring
+# pylint: disable=invalid-name,missing-docstring,missing-param-doc,missing-raises-doc,missing-return-doc
+# pylint: disable=missing-return-type-doc,missing-type-doc
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/interestingness/timedRun.py
+++ b/interestingness/timedRun.py
@@ -53,12 +53,12 @@ def xpkill(p):
     """Based on mozilla-central/source/build/automation.py.in ."""
     try:
         p.kill()
-    except WindowsError:  # pylint: disable=undefined-variable,useless-suppression
+    except WindowsError:  # pylint: disable=undefined-variable
         if not p.poll():
             try:
                 print("Trying to kill the process the first time...")
                 p.kill()  # Verify that the process is really killed.
-            except WindowsError:  # pylint: disable=undefined-variable,useless-suppression
+            except WindowsError:  # pylint: disable=undefined-variable
                 if not p.poll():
                     print("Trying to kill the process the second time...")
                     p.kill()  # Re-verify that the process is really killed.

--- a/interestingness/timedRun.py
+++ b/interestingness/timedRun.py
@@ -54,12 +54,12 @@ def xpkill(p):
     try:
         p.kill()
     except WindowsError:  # pylint: disable=undefined-variable
-        if not p.poll():
+        if p.poll() == 0:
             try:
                 print("Trying to kill the process the first time...")
                 p.kill()  # Verify that the process is really killed.
             except WindowsError:  # pylint: disable=undefined-variable
-                if not p.poll():
+                if p.poll() == 0:
                     print("Trying to kill the process the second time...")
                     p.kill()  # Re-verify that the process is really killed.
 
@@ -151,13 +151,13 @@ def timed_run(commandWithArgs,  # pylint: disable=too-complex,too-many-branches,
     if killed and (os.name != "posix" or rc == -signal.SIGKILL):  # pylint: disable=no-member
         msg = "TIMED OUT"
         sta = TIMED_OUT
-    elif not rc:
+    elif rc == 0:
         msg = "NORMAL"
         sta = NORMAL
     elif rc == ASAN_EXIT_CODE:
         msg = "CRASHED (Address Sanitizer fault)"
         sta = CRASHED
-    elif rc:
+    elif rc > 0:
         msg = "ABNORMAL exit code " + str(rc)
         sta = ABNORMAL
     else:

--- a/interestingness/timedRun.py
+++ b/interestingness/timedRun.py
@@ -18,7 +18,7 @@ import time
 path0 = os.path.dirname(os.path.abspath(__file__))
 path1 = os.path.abspath(os.path.join(path0, os.pardir, 'interestingness'))
 sys.path.append(path1)
-import envVars  # noqa  pylint: disable=relative-import,wrong-import-position
+import envVars  # noqa  pylint: disable=relative-import,useless-suppression,wrong-import-position
 
 ASAN_EXIT_CODE = 77
 
@@ -148,7 +148,7 @@ def timed_run(commandWithArgs,  # pylint: disable=too-complex,too-many-branches,
         else:
             break
 
-    if killed and (os.name != "posix" or rc == -signal.SIGKILL):  # pylint: disable=no-member
+    if killed and (os.name != "posix" or rc == -signal.SIGKILL):  # pylint: disable=no-member,useless-suppression
         msg = "TIMED OUT"
         sta = TIMED_OUT
     elif not rc:

--- a/interestingness/timedRun.py
+++ b/interestingness/timedRun.py
@@ -53,12 +53,12 @@ def xpkill(p):
     """Based on mozilla-central/source/build/automation.py.in ."""
     try:
         p.kill()
-    except WindowsError:  # pylint: disable=undefined-variable
+    except WindowsError:  # pylint: disable=undefined-variable,useless-suppression
         if not p.poll():
             try:
                 print("Trying to kill the process the first time...")
                 p.kill()  # Verify that the process is really killed.
-            except WindowsError:  # pylint: disable=undefined-variable
+            except WindowsError:  # pylint: disable=undefined-variable,useless-suppression
                 if not p.poll():
                     print("Trying to kill the process the second time...")
                     p.kill()  # Re-verify that the process is really killed.

--- a/interestingness/timedRun.py
+++ b/interestingness/timedRun.py
@@ -54,12 +54,12 @@ def xpkill(p):
     try:
         p.kill()
     except WindowsError:  # pylint: disable=undefined-variable
-        if p.poll() == 0:
+        if not p.poll():
             try:
                 print("Trying to kill the process the first time...")
                 p.kill()  # Verify that the process is really killed.
             except WindowsError:  # pylint: disable=undefined-variable
-                if p.poll() == 0:
+                if not p.poll():
                     print("Trying to kill the process the second time...")
                     p.kill()  # Re-verify that the process is really killed.
 
@@ -151,13 +151,13 @@ def timed_run(commandWithArgs,  # pylint: disable=too-complex,too-many-branches,
     if killed and (os.name != "posix" or rc == -signal.SIGKILL):  # pylint: disable=no-member
         msg = "TIMED OUT"
         sta = TIMED_OUT
-    elif rc == 0:
+    elif not rc:
         msg = "NORMAL"
         sta = NORMAL
     elif rc == ASAN_EXIT_CODE:
         msg = "CRASHED (Address Sanitizer fault)"
         sta = CRASHED
-    elif rc > 0:
+    elif rc:
         msg = "ABNORMAL exit code " + str(rc)
         sta = ABNORMAL
     else:

--- a/interestingness/ximport.py
+++ b/interestingness/ximport.py
@@ -6,8 +6,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-"""
-This lets you import an interestingness test given a full path, or given just a filename.
+"""This lets you import an interestingness test given a full path, or given just a filename.
 (assuming it's in the current directory OR in the same directory as ximport)
 """
 

--- a/interestingness/ximport.py
+++ b/interestingness/ximport.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name,missing-return-doc,missing-return-type-doc
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/lithium/examples/arithmetic/product_divides.py
+++ b/lithium/examples/arithmetic/product_divides.py
@@ -27,7 +27,7 @@ def interesting(args, _temp_prefix):
             if line.isdigit():
                 prod *= int(line)
 
-    if prod % mod == 0:
+    if not prod % mod:
         sys.stdout.write("%d is divisible by %d\n" % (prod, mod))
         return True
 

--- a/lithium/examples/arithmetic/product_divides.py
+++ b/lithium/examples/arithmetic/product_divides.py
@@ -27,7 +27,7 @@ def interesting(args, _temp_prefix):
             if line.isdigit():
                 prod *= int(line)
 
-    if not prod % mod:
+    if prod % mod == 0:
         sys.stdout.write("%d is divisible by %d\n" % (prod, mod))
         return True
 

--- a/lithium/examples/arithmetic/product_divides.py
+++ b/lithium/examples/arithmetic/product_divides.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
+# pylint: disable=missing-param-doc,missing-return-doc,missing-return-type-doc,missing-type-doc
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/lithium/examples/arithmetic/product_divides.py
+++ b/lithium/examples/arithmetic/product_divides.py
@@ -5,8 +5,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-"""
-Interesting if the product of the numbers in the file divides the argument.
+"""Interesting if the product of the numbers in the file divides the argument.
 
 e.g. lithium product_divides 35 11.txt
 """
@@ -15,8 +14,7 @@ import sys
 
 
 def interesting(args, _temp_prefix):
-    """
-    simple version for testing
+    """Simple version for testing
     """
     mod = int(args[0])
     filename = args[1]

--- a/lithium/lithium.py
+++ b/lithium/lithium.py
@@ -467,7 +467,7 @@ class MinimizeSurroundingPairs(Minimize):
 
         testcase.writeTestcase(tempFilename("did-round-%d" % chunkSize))
 
-        return (chunksRemoved > 0), testcase
+        return bool(chunksRemoved), testcase
 
 
 class MinimizeBalancedPairs(MinimizeSurroundingPairs):
@@ -537,7 +537,7 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
                 nNormal = normal[lhsChunkIdx]
 
                 # If the chunk is already balanced, try to remove it.
-                if nCurly == 0 and nSquare == 0 and nNormal == 0:
+                if not (nCurly or nSquare or nNormal):
                     testcaseSuggestion = testcase.copy()
                     testcaseSuggestion.parts = (testcaseSuggestion.parts[:chunkLhsStart] +
                                                 testcaseSuggestion.parts[chunkLhsEnd:])
@@ -564,11 +564,11 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
                     nNormal += normal[rhsChunkIdx]
                     if nCurly < 0 or nSquare < 0 or nNormal < 0:
                         break
-                    if nCurly == 0 and nSquare == 0 and nNormal == 0:
+                    if not (nCurly or nSquare or nNormal):
                         break
 
                 # If we have no match, then just skip this pair of chunks.
-                if nCurly != 0 or nSquare != 0 or nNormal != 0:
+                if nCurly or nSquare or nNormal:
                     log.info("Skipping %s because it is 'uninteresting'.", description)
                     chunkStart += chunkSize
                     lhsChunkIdx = self.list_nindex(summary, lhsChunkIdx, "S")
@@ -625,7 +625,7 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
                     nCurly = curly[midChunkIdx]
                     nSquare = square[midChunkIdx]
                     nNormal = normal[midChunkIdx]
-                    if nCurly != 0 or nSquare != 0 or nNormal != 0:
+                    if nCurly or nSquare or nNormal:
                         log.info("Keeping %s because it is 'uninteresting'.", description)
                         chunkMidStart += chunkSize
                         midChunkIdx = self.list_nindex(summary, midChunkIdx, "S")
@@ -703,7 +703,7 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
 
         testcase.writeTestcase(tempFilename("did-round-%d" % chunkSize))
 
-        return (chunksRemoved > 0), testcase
+        return bool(chunksRemoved), testcase
 
 
 class ReplacePropertiesByGlobals(Minimize):
@@ -1295,7 +1295,7 @@ def summaryHeader():
 
 
 def divideRoundingUp(n, d):
-    return (n // d) + (1 if n % d != 0 else 0)
+    return (n // d) + (1 if n % d else 0)
 
 
 def isPowerOfTwo(n):

--- a/lithium/lithium.py
+++ b/lithium/lithium.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # coding=utf-8
-# pylint: disable=invalid-name,missing-docstring,too-many-lines,too-many-statements
+# pylint: disable=invalid-name,missing-docstring,missing-param-doc,missing-return-doc,missing-return-type-doc
+# pylint: disable=missing-type-doc,too-many-lines,too-many-statements
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/lithium/lithium.py
+++ b/lithium/lithium.py
@@ -910,7 +910,7 @@ class ReplaceArgumentsByGlobals(Minimize):
                 if fun is None:
                     fun = match.group(2)
 
-                if match.group(3) == b"":
+                if not match.group(3):
                     args = []
                 else:
                     args = match.group(3).split(b",")
@@ -924,7 +924,7 @@ class ReplaceArgumentsByGlobals(Minimize):
 
             # Match anonymous function definition, which are surrounded by parentheses.
             for match in re.finditer(br"\(function\s*\w*\s*\(((?:\s*\w+\s*(?:,\s*\w+\s*)*)?)\)\s*{", line):
-                if match.group(1) == "":
+                if not match.group(1):
                     args = []
                 else:
                     args = match.group(1).split(",")
@@ -936,9 +936,9 @@ class ReplaceArgumentsByGlobals(Minimize):
                     continue
                 anon = anonymousStack[-1]
                 anonymousStack = anonymousStack[:-1]
-                if match.group(1) == b"" and not anon["defs"]:
+                if not (match.group(1) or anon["defs"]):
                     continue
-                if match.group(1) == b"":
+                if not match.group(1):
                     args = []
                 else:
                     args = match.group(1).split(b",")
@@ -950,7 +950,7 @@ class ReplaceArgumentsByGlobals(Minimize):
             for match in re.finditer(br"((\w+)\s*\(((?:[^()]|\([^,()]*\))*)\))", line):
                 pattern = match.group(1)
                 fun = match.group(2)
-                if match.group(3) == b"":
+                if not match.group(3):
                     args = []
                 else:
                     args = match.group(3).split(b",")

--- a/lithium/lithium.py
+++ b/lithium/lithium.py
@@ -1240,7 +1240,7 @@ class Lithium(object):  # pylint: disable=too-many-instance-attributes
         self.testcase.readTestcase(testcaseFilename)
 
         sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir, "interestingness"))
-        import ximport  # pylint: disable=import-error,useless-suppression
+        import ximport  # pylint: disable=import-error
 
         self.conditionScript = ximport.importRelativeOrAbsolute(extra_args[0])
         self.conditionArgs = extra_args[1:]

--- a/lithium/lithium.py
+++ b/lithium/lithium.py
@@ -1310,7 +1310,7 @@ def largestPowerOfTwoSmallerThan(n):
 
 
 def quantity(n, unit):
-    "Convert a quantity to a string, with correct pluralization."
+    """Convert a quantity to a string, with correct pluralization."""
     r = "%d %s" % (n, unit)
     if n != 1:
         r += "s"

--- a/lithium/lithium.py
+++ b/lithium/lithium.py
@@ -910,7 +910,7 @@ class ReplaceArgumentsByGlobals(Minimize):
                 if fun is None:
                     fun = match.group(2)
 
-                if not match.group(3):
+                if match.group(3) == b"":
                     args = []
                 else:
                     args = match.group(3).split(b",")
@@ -924,7 +924,7 @@ class ReplaceArgumentsByGlobals(Minimize):
 
             # Match anonymous function definition, which are surrounded by parentheses.
             for match in re.finditer(br"\(function\s*\w*\s*\(((?:\s*\w+\s*(?:,\s*\w+\s*)*)?)\)\s*{", line):
-                if not match.group(1):
+                if match.group(1) == "":
                     args = []
                 else:
                     args = match.group(1).split(",")
@@ -936,9 +936,9 @@ class ReplaceArgumentsByGlobals(Minimize):
                     continue
                 anon = anonymousStack[-1]
                 anonymousStack = anonymousStack[:-1]
-                if not (match.group(1) or anon["defs"]):
+                if match.group(1) == b"" and not anon["defs"]:
                     continue
-                if not match.group(1):
+                if match.group(1) == b"":
                     args = []
                 else:
                     args = match.group(1).split(b",")
@@ -950,7 +950,7 @@ class ReplaceArgumentsByGlobals(Minimize):
             for match in re.finditer(br"((\w+)\s*\(((?:[^()]|\([^,()]*\))*)\))", line):
                 pattern = match.group(1)
                 fun = match.group(2)
-                if not match.group(3):
+                if match.group(3) == b"":
                     args = []
                 else:
                     args = match.group(3).split(b",")

--- a/lithium/lithium.py
+++ b/lithium/lithium.py
@@ -467,7 +467,7 @@ class MinimizeSurroundingPairs(Minimize):
 
         testcase.writeTestcase(tempFilename("did-round-%d" % chunkSize))
 
-        return (chunksRemoved > 0), testcase
+        return bool(chunksRemoved), testcase
 
 
 class MinimizeBalancedPairs(MinimizeSurroundingPairs):
@@ -537,7 +537,7 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
                 nNormal = normal[lhsChunkIdx]
 
                 # If the chunk is already balanced, try to remove it.
-                if nCurly == 0 and nSquare == 0 and nNormal == 0:
+                if not (nCurly or nSquare or nNormal):
                     testcaseSuggestion = testcase.copy()
                     testcaseSuggestion.parts = (testcaseSuggestion.parts[:chunkLhsStart] +
                                                 testcaseSuggestion.parts[chunkLhsEnd:])
@@ -564,11 +564,11 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
                     nNormal += normal[rhsChunkIdx]
                     if nCurly < 0 or nSquare < 0 or nNormal < 0:
                         break
-                    if nCurly == 0 and nSquare == 0 and nNormal == 0:
+                    if not (nCurly or nSquare or nNormal):
                         break
 
                 # If we have no match, then just skip this pair of chunks.
-                if nCurly != 0 or nSquare != 0 or nNormal != 0:
+                if nCurly or nSquare or nNormal:
                     log.info("Skipping %s because it is 'uninteresting'.", description)
                     chunkStart += chunkSize
                     lhsChunkIdx = self.list_nindex(summary, lhsChunkIdx, "S")
@@ -625,7 +625,7 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
                     nCurly = curly[midChunkIdx]
                     nSquare = square[midChunkIdx]
                     nNormal = normal[midChunkIdx]
-                    if nCurly != 0 or nSquare != 0 or nNormal != 0:
+                    if nCurly or nSquare or nNormal:
                         log.info("Keeping %s because it is 'uninteresting'.", description)
                         chunkMidStart += chunkSize
                         midChunkIdx = self.list_nindex(summary, midChunkIdx, "S")
@@ -703,7 +703,7 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
 
         testcase.writeTestcase(tempFilename("did-round-%d" % chunkSize))
 
-        return (chunksRemoved > 0), testcase
+        return bool(chunksRemoved), testcase
 
 
 class ReplacePropertiesByGlobals(Minimize):
@@ -924,7 +924,7 @@ class ReplaceArgumentsByGlobals(Minimize):
 
             # Match anonymous function definition, which are surrounded by parentheses.
             for match in re.finditer(br"\(function\s*\w*\s*\(((?:\s*\w+\s*(?:,\s*\w+\s*)*)?)\)\s*{", line):
-                if match.group(1) == "":
+                if match.group(1) == b"":
                     args = []
                 else:
                     args = match.group(1).split(",")

--- a/lithium/lithium.py
+++ b/lithium/lithium.py
@@ -1155,12 +1155,12 @@ class Lithium(object):  # pylint: disable=too-many-instance-attributes
 
         defaultStrategy = "minimize"
         assert defaultStrategy in strategies
-        parser = ArgParseTry(add_help=False)
-        parser.add_argument(
+        strategyParser = ArgParseTry(add_help=False)
+        strategyParser.add_argument(
             "--strategy",
             default=defaultStrategy,
             choices=strategies.keys())
-        args = parser.parse_known_args(argv)
+        args = strategyParser.parse_known_args(argv)
         self.strategy = strategies.get(args[0].strategy if args else None, strategies[defaultStrategy])()
 
         parser = argparse.ArgumentParser(

--- a/lithium/lithium.py
+++ b/lithium/lithium.py
@@ -493,7 +493,7 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
     def list_fiveParts(lst, step, f, s, t):
         return (lst[:f], lst[f:s], lst[s:(s + step)], lst[(s + step):(t + step)], lst[(t + step):])
 
-    def tryRemovingChunks(self,  # pylint: disable=too-many-branches,too-many-locals
+    def tryRemovingChunks(self,  # pylint: disable=too-complex,too-many-branches,too-many-locals
                           chunkSize, testcase, interesting, tempFilename):
         """Make a single run through the testcase, trying to remove chunks of size chunkSize.
 
@@ -766,7 +766,7 @@ class ReplacePropertiesByGlobals(Minimize):
 
         return 0, (finalChunkSize == 1 and self.minimizeRepeat != "never"), testcase
 
-    def tryMakingGlobals(self,  # pylint: disable=too-many-arguments,too-many-branches,too-many-locals
+    def tryMakingGlobals(self,  # pylint: disable=too-complex,too-many-arguments,too-many-branches,too-many-locals
                          chunkSize, numChars, testcase, interesting, tempFilename):
         """Make a single run through the testcase, trying to remove chunks of size chunkSize.
 
@@ -889,7 +889,7 @@ class ReplaceArgumentsByGlobals(Minimize):
         return 0, False, testcase
 
     @staticmethod
-    def tryArgumentsAsGlobals(roundNum,  # pylint: disable=too-many-branches,too-many-locals
+    def tryArgumentsAsGlobals(roundNum,  # pylint: disable=too-complex,too-many-branches,too-many-locals
                               testcase, interesting, tempFilename):
         """Make a single run through the testcase, trying to remove chunks of size chunkSize.
 
@@ -1132,7 +1132,7 @@ class Lithium(object):  # pylint: disable=too-many-instance-attributes
             if self.lastInteresting is not None:
                 self.lastInteresting.writeTestcase()
 
-    def processArgs(self, argv=None):  # pylint: disable=too-many-locals
+    def processArgs(self, argv=None):  # pylint: disable=too-complex,too-many-locals
         # Build list of strategies and testcase types
         strategies = {}
         testcaseTypes = {}

--- a/lithium/lithium.py
+++ b/lithium/lithium.py
@@ -1240,7 +1240,7 @@ class Lithium(object):  # pylint: disable=too-many-instance-attributes
         self.testcase.readTestcase(testcaseFilename)
 
         sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir, "interestingness"))
-        import ximport  # pylint: disable=import-error
+        import ximport  # pylint: disable=import-error,useless-suppression
 
         self.conditionScript = ximport.importRelativeOrAbsolute(extra_args[0])
         self.conditionArgs = extra_args[1:]

--- a/lithium/lithium.py
+++ b/lithium/lithium.py
@@ -467,7 +467,7 @@ class MinimizeSurroundingPairs(Minimize):
 
         testcase.writeTestcase(tempFilename("did-round-%d" % chunkSize))
 
-        return bool(chunksRemoved), testcase
+        return (chunksRemoved > 0), testcase
 
 
 class MinimizeBalancedPairs(MinimizeSurroundingPairs):
@@ -537,7 +537,7 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
                 nNormal = normal[lhsChunkIdx]
 
                 # If the chunk is already balanced, try to remove it.
-                if not (nCurly or nSquare or nNormal):
+                if nCurly == 0 and nSquare == 0 and nNormal == 0:
                     testcaseSuggestion = testcase.copy()
                     testcaseSuggestion.parts = (testcaseSuggestion.parts[:chunkLhsStart] +
                                                 testcaseSuggestion.parts[chunkLhsEnd:])
@@ -564,11 +564,11 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
                     nNormal += normal[rhsChunkIdx]
                     if nCurly < 0 or nSquare < 0 or nNormal < 0:
                         break
-                    if not (nCurly or nSquare or nNormal):
+                    if nCurly == 0 and nSquare == 0 and nNormal == 0:
                         break
 
                 # If we have no match, then just skip this pair of chunks.
-                if nCurly or nSquare or nNormal:
+                if nCurly != 0 or nSquare != 0 or nNormal != 0:
                     log.info("Skipping %s because it is 'uninteresting'.", description)
                     chunkStart += chunkSize
                     lhsChunkIdx = self.list_nindex(summary, lhsChunkIdx, "S")
@@ -625,7 +625,7 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
                     nCurly = curly[midChunkIdx]
                     nSquare = square[midChunkIdx]
                     nNormal = normal[midChunkIdx]
-                    if nCurly or nSquare or nNormal:
+                    if nCurly != 0 or nSquare != 0 or nNormal != 0:
                         log.info("Keeping %s because it is 'uninteresting'.", description)
                         chunkMidStart += chunkSize
                         midChunkIdx = self.list_nindex(summary, midChunkIdx, "S")
@@ -703,7 +703,7 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
 
         testcase.writeTestcase(tempFilename("did-round-%d" % chunkSize))
 
-        return bool(chunksRemoved), testcase
+        return (chunksRemoved > 0), testcase
 
 
 class ReplacePropertiesByGlobals(Minimize):
@@ -1295,7 +1295,7 @@ def summaryHeader():
 
 
 def divideRoundingUp(n, d):
-    return (n // d) + (1 if n % d else 0)
+    return (n // d) + (1 if n % d != 0 else 0)
 
 
 def isPowerOfTwo(n):

--- a/lithium/lithium.py
+++ b/lithium/lithium.py
@@ -21,8 +21,7 @@ class LithiumError(Exception):
 
 
 class Testcase(object):
-    """
-    Abstract testcase class.
+    """Abstract testcase class.
 
     Implementers should define readTestcaseLine() and writeTestcase() methods.
     """
@@ -155,8 +154,7 @@ class TestcaseSymbol(TestcaseLine):
 
 
 class Strategy(object):
-    """
-    Abstract minimization strategy class
+    """Abstract minimization strategy class
 
     Implementers should define a main() method which takes a testcase and calls the interesting callback repeatedly
     to minimize the testcase.

--- a/lithium/tests.py
+++ b/lithium/tests.py
@@ -149,7 +149,8 @@ def ispow2(n):
     # if the input is representable as a float, compare the result to math library
     if orig <= sys.float_info.max:
         math_result = math.log(orig) / math.log(2)
-        diff = abs(math_result - round(math_result))  # diff to the next closest integer
+        # diff to the next closest integer
+        diff = abs(math_result - round(math_result))  # pylint: disable=round-builtin,useless-suppression
         math_result = diff < 10**-(sys.float_info.dig - 1)  # float_info.dig is the # of decimal digits representable
         assert result == math_result, "ispow2(n) did not match math.log(n)/math.log(2) for n = %d" % orig
     return result

--- a/lithium/tests.py
+++ b/lithium/tests.py
@@ -134,8 +134,7 @@ class DummyInteresting(object):
 
 
 def ispow2(n):
-    """
-    simple version for testing
+    """Simple version for testing
     """
     assert isinstance(n, int) or n.is_integer(), "ispow2() only works for integers, %r is not an integer" % n
     assert n >= 1, "domain error"
@@ -156,8 +155,7 @@ def ispow2(n):
 
 
 def divceil(n, d):
-    """
-    simple version for testing
+    """Simple version for testing
     """
     q = n // d
     r = n % d

--- a/lithium/tests.py
+++ b/lithium/tests.py
@@ -17,7 +17,7 @@ import sys
 import tempfile
 import unittest
 
-import lithium  # pylint: disable=relative-import
+import lithium  # pylint: disable=relative-import,useless-suppression
 
 log = logging.getLogger("lithium_test")
 logging.basicConfig(level=logging.DEBUG)

--- a/lithium/tests.py
+++ b/lithium/tests.py
@@ -42,11 +42,11 @@ class TestCase(unittest.TestCase):
 
     if sys.version_info.major == 2:
 
-        def assertRegex(self, *args, **kwds):  # pylint: disable=arguments-differ
-            return self.assertRegexpMatches(*args, **kwds)  # pylint: disable=deprecated-method
+        def assertRegex(self, *args, **kwds):  # pylint: disable=arguments-differ,useless-suppression
+            return self.assertRegexpMatches(*args, **kwds)  # pylint: disable=deprecated-method,useless-suppression
 
-        def assertRaisesRegex(self, *args, **kwds):  # pylint: disable=arguments-differ
-            return self.assertRaisesRegexp(*args, **kwds)  # pylint: disable=deprecated-method
+        def assertRaisesRegex(self, *args, **kwds):  # pylint: disable=arguments-differ,useless-suppression
+            return self.assertRaisesRegexp(*args, **kwds)  # pylint: disable=deprecated-method,useless-suppression
 
     if sys.version_info[:2] < (3, 4):
         #

--- a/lithium/tests.py
+++ b/lithium/tests.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # coding=utf-8
-# pylint: disable=invalid-name,missing-docstring,too-few-public-methods
+# pylint: disable=invalid-name,missing-docstring,missing-param-doc,missing-return-doc,missing-return-type-doc
+# pylint: disable=missing-type-doc,too-few-public-methods
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/lithium/tests.py
+++ b/lithium/tests.py
@@ -19,7 +19,7 @@ import sys
 import tempfile
 import unittest
 
-import lithium  # pylint: disable=relative-import,useless-suppression
+import lithium  # pylint: disable=relative-import
 
 log = logging.getLogger("lithium_test")
 logging.basicConfig(level=logging.DEBUG)

--- a/lithium/tests.py
+++ b/lithium/tests.py
@@ -152,7 +152,7 @@ def ispow2(n):
     if orig <= sys.float_info.max:
         math_result = math.log(orig) / math.log(2)
         # diff to the next closest integer
-        diff = abs(math_result - round(math_result))  # pylint: disable=round-builtin,useless-suppression
+        diff = abs(math_result - round(math_result))  # pylint: disable=round-builtin
         math_result = diff < 10**-(sys.float_info.dig - 1)  # float_info.dig is the # of decimal digits representable
         assert result == math_result, "ispow2(n) did not match math.log(n)/math.log(2) for n = %d" % orig
     return result
@@ -175,7 +175,7 @@ class HelperTests(TestCase):
 
     def test_divideRoundingUp(self):
         for _ in range(10000):
-            n = random.randint(1, sys.maxint)  # pylint: disable=sys-max-int,useless-suppression
+            n = random.randint(1, sys.maxint)  # pylint: disable=sys-max-int
             d = random.randint(1, n)
             try:
                 self.assertEqual(divceil(n, d), lithium.divideRoundingUp(n, d))
@@ -197,7 +197,7 @@ class HelperTests(TestCase):
                 raise
         # try 10000 random integers >= 10000
         for _ in range(10000):
-            r = random.randint(10000, sys.maxint)  # pylint: disable=sys-max-int,useless-suppression
+            r = random.randint(10000, sys.maxint)  # pylint: disable=sys-max-int
             try:
                 self.assertEqual(ispow2(r), lithium.isPowerOfTwo(r))
             except Exception:
@@ -224,7 +224,7 @@ class HelperTests(TestCase):
                 raise
         # try 10000 random integers >= 10000
         for _ in range(10000):
-            r = random.randint(10000, sys.maxint)  # pylint: disable=sys-max-int,useless-suppression
+            r = random.randint(10000, sys.maxint)  # pylint: disable=sys-max-int
             try:
                 check_result(lithium.largestPowerOfTwoSmallerThan(r), r)
             except Exception:

--- a/lithium/tests.py
+++ b/lithium/tests.py
@@ -7,6 +7,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+from __future__ import division
+
 import collections
 import logging
 import math

--- a/lithium/tests.py
+++ b/lithium/tests.py
@@ -175,7 +175,7 @@ class HelperTests(TestCase):
 
     def test_divideRoundingUp(self):
         for _ in range(10000):
-            n = random.randint(1, sys.maxint)
+            n = random.randint(1, sys.maxint)  # pylint: disable=sys-max-int,useless-suppression
             d = random.randint(1, n)
             try:
                 self.assertEqual(divceil(n, d), lithium.divideRoundingUp(n, d))
@@ -197,7 +197,7 @@ class HelperTests(TestCase):
                 raise
         # try 10000 random integers >= 10000
         for _ in range(10000):
-            r = random.randint(10000, sys.maxint)
+            r = random.randint(10000, sys.maxint)  # pylint: disable=sys-max-int,useless-suppression
             try:
                 self.assertEqual(ispow2(r), lithium.isPowerOfTwo(r))
             except Exception:
@@ -224,7 +224,7 @@ class HelperTests(TestCase):
                 raise
         # try 10000 random integers >= 10000
         for _ in range(10000):
-            r = random.randint(10000, sys.maxint)
+            r = random.randint(10000, sys.maxint)  # pylint: disable=sys-max-int,useless-suppression
             try:
                 check_result(lithium.largestPowerOfTwoSmallerThan(r), r)
             except Exception:

--- a/lithium/tests.py
+++ b/lithium/tests.py
@@ -44,11 +44,11 @@ class TestCase(unittest.TestCase):
 
     if sys.version_info.major == 2:
 
-        def assertRegex(self, *args, **kwds):  # pylint: disable=arguments-differ,useless-suppression
-            return self.assertRegexpMatches(*args, **kwds)  # pylint: disable=deprecated-method,useless-suppression
+        def assertRegex(self, *args, **kwds):  # pylint: disable=arguments-differ
+            return self.assertRegexpMatches(*args, **kwds)  # pylint: disable=deprecated-method
 
-        def assertRaisesRegex(self, *args, **kwds):  # pylint: disable=arguments-differ,useless-suppression
-            return self.assertRaisesRegexp(*args, **kwds)  # pylint: disable=deprecated-method,useless-suppression
+        def assertRaisesRegex(self, *args, **kwds):  # pylint: disable=arguments-differ
+            return self.assertRaisesRegexp(*args, **kwds)  # pylint: disable=deprecated-method
 
     if sys.version_info[:2] < (3, 4):
         #


### PR DESCRIPTION
I've enabled all pylint extensions and most disabled-by-default messages, sans:

* `locally-disabled`: We do intentionally disable, so this remains disabled.
* `no-absolute-import`: This can be removed after the migration to Python 3 away from 2 is fully complete.
* `suppressed-message`: We make lots of use of suppressions intentionally, so this remains disabled.

and added suppressions where necessary, and fixed the ones that were fairly straightforward.

This should also fix the weird issue brought up at our video meeting concerning `redefined-variable-type`, which only showed up on @jschwartzentruber's computer, and not mine nor Travis/AppVeyor.

Ideally this should land before the upcoming imports refactor, as all the linter tests on Travis/AppVeyor are now passing.