### PR TITLE
Add venv & interestingness tests

### DIFF
--- a/lithium/tests.py
+++ b/lithium/tests.py
@@ -294,9 +294,9 @@ class InterestingnessTests(TestCase):
             # scan the log output to see how many tests were performed
             for rec in test_logs.records:
                 if "Tests performed:" in rec.msg:
-                    self.assertEqual(rec.args[0], 2) # should have run 2x
+                    self.assertEqual(rec.args[0], 2)  # should have run 2x
                     found_rec = True
-            self.assertTrue(found_rec) # check that we hit the check ;)
+            self.assertTrue(found_rec)  # check that we hit the check ;)
 
 
 class LithiumTests(TestCase):

--- a/lithium/tests.py
+++ b/lithium/tests.py
@@ -235,7 +235,12 @@ class HelperTests(TestCase):
 
 
 class InterestingnessTests(TestCase):
-    cat_exe = "type" if platform.system() == "Windows" else "cat"
+    cat_cmd = [sys.executable, "-c", ("import sys;"
+                                      "[sys.stdout.write(f.read()) "
+                                      " for f in "
+                                      "     ([open(a) for a in sys.argv[1:]] or "
+                                      "      [sys.stdin])"
+                                      "]")]
     list_exe = "dir" if platform.system() == "Windows" else "ls"
     sleep_cmd = [sys.executable, "-c", "import time;time.sleep(3)"]
 
@@ -287,7 +292,7 @@ class InterestingnessTests(TestCase):
 
         # check for a known string, twice
         with self.assertLogs("lithium") as test_logs:
-            result = l.main(["range", "0", "2", "outputs", "hello", self.cat_exe, "temp.js"])
+            result = l.main(["range", "0", "2", "outputs", "hello"] + self.cat_cmd + ["temp.js"])
             self.assertEqual(result, 0)
             found_rec = False
             # scan the log output to see how many tests were performed

--- a/lithium/tests.py
+++ b/lithium/tests.py
@@ -246,8 +246,8 @@ class InterestingnessTests(TestCase):
             pass
 
         # check that `ls` doesn't crash
-        l.processArgs(["crashes", self.list_exe, "temp.js"])
-        self.assertEqual(l.run(), 1)
+        result = l.main(["crashes", self.list_exe, "temp.js"])
+        self.assertEqual(result, 1)
 
         # no easy target to test the opposite case ...
 
@@ -257,12 +257,12 @@ class InterestingnessTests(TestCase):
             pass
 
         # test that `sleep 3` hangs over 1s
-        l.processArgs(["--testcase", "temp.js", "hangs", "1"] + self.sleep_cmd)
-        self.assertEqual(l.run(), 0)
+        result = l.main(["--testcase", "temp.js", "hangs", "1"] + self.sleep_cmd)
+        self.assertEqual(result, 0)
 
         # test that `ls temp.js` does not hang over 1s
-        l.processArgs(["hangs", "1", self.list_exe, "temp.js"])
-        self.assertEqual(l.run(), 1)
+        result = l.main(["hangs", "1", self.list_exe, "temp.js"])
+        self.assertEqual(result, 1)
 
     def test_outputs(self):
         l = lithium.Lithium()
@@ -270,16 +270,16 @@ class InterestingnessTests(TestCase):
             pass
 
         # test that `ls temp.js` contains "temp.js"
-        l.processArgs(["outputs", "temp.js", self.list_exe, "temp.js"])
-        self.assertEqual(l.run(), 0)
+        result = l.main(["outputs", "temp.js", self.list_exe, "temp.js"])
+        self.assertEqual(result, 0)
 
         # test that `ls temp.js` does not contain "blah"
-        l.processArgs(["outputs", "blah", self.list_exe, "temp.js"])
-        self.assertEqual(l.run(), 1)
+        result = l.main(["outputs", "blah", self.list_exe, "temp.js"])
+        self.assertEqual(result, 1)
 
         # test that regex matches work too
-        l.processArgs(["outputs", "--regex", "^.*js$", self.list_exe, "temp.js"])
-        self.assertEqual(l.run(), 0)
+        result = l.main(["outputs", "--regex", "^.*js$", self.list_exe, "temp.js"])
+        self.assertEqual(result, 0)
 
     def test_range(self):
         l = lithium.Lithium()
@@ -287,9 +287,9 @@ class InterestingnessTests(TestCase):
             tempf.write("hello")
 
         # check for a known string, twice
-        l.processArgs(["range", "0", "2", "outputs", "hello", self.cat_exe, "temp.js"])
         with self.assertLogs("lithium") as test_logs:
-            self.assertEqual(l.run(), 0)
+            result = l.main(["range", "0", "2", "outputs", "hello", self.cat_exe, "temp.js"])
+            self.assertEqual(result, 0)
             found_rec = False
             # scan the log output to see how many tests were performed
             for rec in test_logs.records:

--- a/lithium/tests.py
+++ b/lithium/tests.py
@@ -642,8 +642,8 @@ class SetupTests(TestCase):
         else:
             import venv  # noqa pylint: disable=import-error,unused-import
             venv.create("testenv", with_pip=True)
-        python_exe = os.path.join("testenv", "bin", "python")
-        lithium_exe = os.path.join("testenv", "bin", "lithium")
+        python_exe = os.path.join("testenv", "Scripts" if platform.system() == "Windows" else "bin", "python")
+        lithium_exe = os.path.join("testenv", "Scripts" if platform.system() == "Windows" else "bin", "lithium")
         subprocess.check_output([python_exe, "-m", "pip", "install", "pytest"])
 
         log.info("installing lithium in virtualenv")

--- a/lithium/tests.py
+++ b/lithium/tests.py
@@ -235,7 +235,7 @@ class HelperTests(TestCase):
                 raise
 
 
-class InterestingTests(TestCase):
+class InterestingnessTests(TestCase):
     cat_exe = "type" if sys.platform.startswith("win") else "cat"
     list_exe = "dir" if sys.platform.startswith("win") else "ls"
     sleep_cmd = [sys.executable, "-c", "import time;time.sleep(3)"]
@@ -653,4 +653,4 @@ class SetupTests(TestCase):
         test_path = os.path.join(os.path.dirname(path.decode(sys.getfilesystemencoding())), "lithium", "tests.py")
         subprocess.check_call([python_exe, "-m", "pytest",
                                test_path + "::LithiumTests",
-                               test_path + "::InterestingTests"])
+                               test_path + "::InterestingnessTests"])

--- a/lithium/tests.py
+++ b/lithium/tests.py
@@ -632,7 +632,7 @@ class TestcaseTests(TestCase):
 class SetupTests(TestCase):
 
     def test_installed(self):  # pylint: disable=no-self-use
-        "lithium module tests"
+        """lithium module tests"""
         log.info("creating virtualenv")
         if sys.version_info.major == 2:
             subprocess.check_call([sys.executable, "-m", "virtualenv", "--system-site-packages", "testenv"])

--- a/lithium/tests.py
+++ b/lithium/tests.py
@@ -20,10 +20,6 @@ import subprocess
 import sys
 import tempfile
 import unittest
-if sys.version_info.major == 2:
-    import virtualenv  # noqa pylint: disable=import-error,unused-import
-else:
-    import venv  # noqa pylint: disable=import-error,unused-import
 
 import lithium  # noqa pylint: disable=relative-import,wrong-import-position
 
@@ -635,11 +631,15 @@ class SetupTests(TestCase):
         """lithium module tests"""
         log.info("creating virtualenv")
         if sys.version_info.major == 2:
-            subprocess.check_call([sys.executable, "-m", "virtualenv", "--system-site-packages", "testenv"])
+            # try the import here so the error message is clearer if it's missing
+            import virtualenv  # noqa pylint: disable=import-error,unused-import,unused-variable
+            subprocess.check_call([sys.executable, "-m", "virtualenv", "testenv"])
         else:
-            venv.create("testenv", system_site_packages=True)
+            import venv  # noqa pylint: disable=import-error,unused-import
+            venv.create("testenv", with_pip=True)
         python_exe = os.path.join("testenv", "bin", "python")
         lithium_exe = os.path.join("testenv", "bin", "lithium")
+        subprocess.check_output([python_exe, "-m", "pip", "install", "pytest"])
 
         log.info("installing lithium in virtualenv")
         subprocess.check_call([python_exe, os.path.join(os.path.dirname(__file__), os.pardir, "setup.py"), "install"])

--- a/lithium/tests.py
+++ b/lithium/tests.py
@@ -12,11 +12,16 @@ import math
 import os
 import random
 import shutil
+import subprocess
 import sys
 import tempfile
 import unittest
+if sys.version_info.major == 2:
+    import virtualenv  # noqa pylint: disable=import-error,unused-import
+else:
+    import venv  # noqa pylint: disable=import-error,unused-import
 
-import lithium  # pylint: disable=relative-import
+import lithium  # noqa pylint: disable=relative-import,wrong-import-position
 
 log = logging.getLogger("lithium_test")
 logging.basicConfig(level=logging.DEBUG)
@@ -228,6 +233,70 @@ class HelperTests(TestCase):
             except Exception:
                 log.debug("r = %d", r)
                 raise
+
+
+class InterestingTests(TestCase):
+    cat_exe = "type" if sys.platform.startswith("win") else "cat"
+    list_exe = "dir" if sys.platform.startswith("win") else "ls"
+    sleep_cmd = [sys.executable, "-c", "import time;time.sleep(3)"]
+
+    def test_crashes(self):
+        l = lithium.Lithium()
+        with open("temp.js", "w"):
+            pass
+
+        # check that `ls` doesn't crash
+        l.processArgs(["crashes", self.list_exe, "temp.js"])
+        self.assertEqual(l.run(), 1)
+
+        # no easy target to test the opposite case ...
+
+    def test_hangs(self):
+        l = lithium.Lithium()
+        with open("temp.js", "w"):
+            pass
+
+        # test that `sleep 3` hangs over 1s
+        l.processArgs(["--testcase", "temp.js", "hangs", "1"] + self.sleep_cmd)
+        self.assertEqual(l.run(), 0)
+
+        # test that `ls temp.js` does not hang over 1s
+        l.processArgs(["hangs", "1", self.list_exe, "temp.js"])
+        self.assertEqual(l.run(), 1)
+
+    def test_outputs(self):
+        l = lithium.Lithium()
+        with open("temp.js", "w"):
+            pass
+
+        # test that `ls temp.js` contains "temp.js"
+        l.processArgs(["outputs", "temp.js", self.list_exe, "temp.js"])
+        self.assertEqual(l.run(), 0)
+
+        # test that `ls temp.js` does not contain "blah"
+        l.processArgs(["outputs", "blah", self.list_exe, "temp.js"])
+        self.assertEqual(l.run(), 1)
+
+        # test that regex matches work too
+        l.processArgs(["outputs", "--regex", "^.*js$", self.list_exe, "temp.js"])
+        self.assertEqual(l.run(), 0)
+
+    def test_range(self):
+        l = lithium.Lithium()
+        with open("temp.js", "w") as tempf:
+            tempf.write("hello")
+
+        # check for a known string, twice
+        l.processArgs(["range", "0", "2", "outputs", "hello", self.cat_exe, "temp.js"])
+        with self.assertLogs("lithium") as test_logs:
+            self.assertEqual(l.run(), 0)
+            found_rec = False
+            # scan the log output to see how many tests were performed
+            for rec in test_logs.records:
+                if "Tests performed:" in rec.msg:
+                    self.assertEqual(rec.args[0], 2) # should have run 2x
+                    found_rec = True
+            self.assertTrue(found_rec) # check that we hit the check ;)
 
 
 class LithiumTests(TestCase):
@@ -555,3 +624,33 @@ class TestcaseTests(TestCase):
         with self.assertRaisesRegex(lithium.LithiumError,
                                     r"^The testcase \(a\.txt\) has a line containing 'DDBEGIN' but no"):
             t.readTestcase("a.txt")
+
+
+class SetupTests(TestCase):
+
+    def test_installed(self):  # pylint: disable=no-self-use
+        "lithium module tests"
+        log.info("creating virtualenv")
+        if sys.version_info.major == 2:
+            subprocess.check_call([sys.executable, "-m", "virtualenv", "--system-site-packages", "testenv"])
+        else:
+            venv.create("testenv", system_site_packages=True)
+        python_exe = os.path.join("testenv", "bin", "python")
+        lithium_exe = os.path.join("testenv", "bin", "lithium")
+
+        log.info("installing lithium in virtualenv")
+        subprocess.check_call([python_exe, os.path.join(os.path.dirname(__file__), os.pardir, "setup.py"), "install"])
+
+        log.info("running lithium -h in virtualenv")
+        subprocess.check_call([lithium_exe, "-h"])
+
+        log.info("importing lithium in virtualenv")
+        subprocess.check_call([python_exe, "-c", "import lithium;import lithium.interestingness"])
+
+        # run a subset of tests to make sure lithium works in the virtualenv
+        log.info("re-running some lithium tests in virtualenv")
+        path = subprocess.check_output([python_exe, "-c", "import lithium;print(lithium.__file__)"])
+        test_path = os.path.join(os.path.dirname(path.decode(sys.getfilesystemencoding())), "lithium", "tests.py")
+        subprocess.check_call([python_exe, "-m", "pytest",
+                               test_path + "::LithiumTests",
+                               test_path + "::InterestingTests"])

--- a/lithium/tests.py
+++ b/lithium/tests.py
@@ -13,6 +13,7 @@ import collections
 import logging
 import math
 import os
+import platform
 import random
 import shutil
 import subprocess
@@ -238,8 +239,8 @@ class HelperTests(TestCase):
 
 
 class InterestingnessTests(TestCase):
-    cat_exe = "type" if sys.platform.startswith("win") else "cat"
-    list_exe = "dir" if sys.platform.startswith("win") else "ls"
+    cat_exe = "type" if platform.system() == "Windows" else "cat"
+    list_exe = "dir" if platform.system() == "Windows" else "ls"
     sleep_cmd = [sys.executable, "-c", "import time;time.sleep(3)"]
 
     def test_crashes(self):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import os
 from setuptools import setup
+
+CWD = os.path.dirname(__file__)
 
 if __name__ == "__main__":
     setup(name="lithium",
@@ -22,5 +25,5 @@ if __name__ == "__main__":
               "lithium/examples/*.*",
               "lithium/examples/arithmetic/*"
           ]},
-          package_dir={"lithium": ""},
+          package_dir={"lithium": CWD},
           zip_safe=False)


### PR DESCRIPTION
This adds tests to make sure setup.py doesn't break, and that interesting tests work as expected.

Calling LithiumTests.test_arithmetic in the venv also ensures that we can call interestingness scripts by path (not part of the lithium module).

This is a cleanup of some of the travis/appveyor tests @nth10sd came up with in #28 & #33 by porting them to unittests.