### PR TITLE
Add .gitattributes file specifying LF line ending for 11.txt file, for tests to pass on Windows.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+# 11.txt should have LF line endings or else character reduction tests fail on Windows
+# AppVeyor by default checks out LF line endings, see:
+# http://help.appveyor.com/discussions/problems/671-coreautocrlf
+11.txt text eol=lf


### PR DESCRIPTION
Git on Windows by default checks out CRLF for some files. This causes character reduction tests of 11.txt to fail, as it will now have CRLF line endings (`\r\n` -  2 chars) instead of LF (`\n` - 1 char) line ending.

Explicitly specifying that 11.txt should only have LF line endings solves this issue. FWIW, AppVeyor did not show this issue because of `core.autocrlf input` [by default](http://help.appveyor.com/discussions/problems/671-coreautocrlf).

The log for this issue is found in #42.