### PR TITLE
Add a new testcase splitter: jsstr (-j/--js)

### DIFF
--- a/lithium/lithium.py
+++ b/lithium/lithium.py
@@ -1284,6 +1284,7 @@ class Lithium(object):  # pylint: disable=too-many-instance-attributes
 
         self.tempDir = args.tempdir
         atom = TestcaseChar.atom if args.char else TestcaseLine.atom
+        atom = TestcaseJsStr.atom if args.js else atom
         atom = TestcaseSymbol.atom if args.symbol else atom
 
         extra_args = args.extra_args[0]

--- a/lithium/lithium.py
+++ b/lithium/lithium.py
@@ -135,9 +135,18 @@ class TestcaseChar(TestcaseLine):
 
 
 class TestcaseJsStr(TestcaseChar):
+    """Testcase type for splitting JS strings byte-wise.
+
+    Data between JS string contents (including the string quotes themselves!) will be a single token for reduction.
+
+    Escapes are also kept together and treated as a single token for reduction.
+    ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#Escape_notation
+    """
     atom = "jsstr"
 
     def readTestcase(self, filename):
+        # these are temporary attributes used to track state in readTestcaseLine (called by super().readTestcase)
+        # they are both deleted after the call below and not available in the instance normally
         self._instr = None  # pylint: disable=attribute-defined-outside-init
         self._chars = []  # pylint: disable=attribute-defined-outside-init
 

--- a/lithium/lithium.py
+++ b/lithium/lithium.py
@@ -134,6 +134,63 @@ class TestcaseChar(TestcaseLine):
             self.parts.append(line[i:i + 1])
 
 
+class TestcaseJsStr(TestcaseChar):
+    atom = "jsstr"
+
+    def readTestcase(self, filename):
+        self._instr = None  # pylint: disable=attribute-defined-outside-init
+        self._chars = []  # pylint: disable=attribute-defined-outside-init
+
+        super(TestcaseJsStr, self).readTestcase(filename)
+
+        assert self._instr is None, "Unexpected EOF looking for end of string (%s)" % self._instr
+        del self._instr
+
+        # self._chars is a list of all the indices in self.parts which are chars
+        # merge all the non-chars since this was parsed line-wise
+
+        chars = self._chars
+        del self._chars
+
+        # beginning and end are special because we can put them in self.before/self.after
+        if chars:
+            off = -chars[0]
+            if off:
+                header, self.parts = b"".join(self.parts[:-off]), self.parts[-off:]
+                self.before = self.before + header
+            if chars[-1] != len(self.parts) + off:
+                self.parts, footer = self.parts[:chars[-1] + 1 + off], b"".join(self.parts[chars[-1] + 1 + off:])
+                self.after = footer + self.after
+
+        # now scan for chars with a gap > 2 between, which means we can merge
+        for char1, char2 in zip(chars, chars[1:]):
+            if (char2 - char1) > 2:
+                self.parts[off + char1 + 1:off + char2] = [b"".join(self.parts[off + char1 + 1:off + char2])]
+                off += char1 - char2 + 2
+
+    def readTestcaseLine(self, line):
+        last = 0
+        while True:
+            if self._instr:
+                match = re.match(br"(\\u[0-9A-Fa-f]{4}|\\x[0-9A-Fa-f]{2}|\\u\{[0-9A-Fa-f]+\}|\\.|.)", line[last:],
+                                 re.DOTALL)
+                if not match:
+                    break
+                self._chars.append(len(self.parts))
+                if match.group(0) == self._instr:
+                    self._instr = None  # pylint: disable=attribute-defined-outside-init
+                    self._chars.pop()
+            else:
+                match = re.search(br"""['"]""", line[last:])
+                if not match:
+                    break
+                self._instr = match.group(0)  # pylint: disable=attribute-defined-outside-init
+            self.parts.append(line[last:last + match.end(0)])
+            last += match.end(0)
+        if last != len(line):
+            self.parts.append(line[last:])
+
+
 class TestcaseSymbol(TestcaseLine):
     atom = "symbol-delimiter"
     DEFAULT_CUT_AFTER = b"?=;{["
@@ -1189,6 +1246,10 @@ class Lithium(object):  # pylint: disable=too-many-instance-attributes
             action="store_true",
             help="Don't treat lines as atomic units; "
                  "treat the file as a sequence of characters rather than a sequence of lines.")
+        grp_atoms.add_argument(
+            "-j", "--js",
+            action="store_true",
+            help="Same as --char but only operate within JS strings, keeping escapes intact.")
         grp_atoms.add_argument(
             "-s", "--symbol",
             action="store_true",

--- a/lithium/test_lithium.py
+++ b/lithium/test_lithium.py
@@ -23,6 +23,7 @@ import lithium  # pylint: disable=relative-import
 
 log = logging.getLogger("lithium_test")
 logging.basicConfig(level=logging.DEBUG)
+logging.getLogger("flake8").setLevel(logging.WARNING)
 
 
 # python 3 has unlimited precision integers
@@ -509,6 +510,26 @@ class TestcaseTests(TestCase):
         self.assertEqual(t.before, b"pre\nDDBEGIN\n")
         self.assertEqual(t.parts, [b"d", b"a", b"t", b"a", b"\n", b"2"])
         self.assertEqual(t.after, b"\nDDEND\npost\n")
+
+    def test_jsstr(self):
+        t = lithium.TestcaseJsStr()
+        with open("a.txt", "wb") as f:
+            f.write(b"pre\n")
+            f.write(b"DDBEGIN\n")
+            f.write(b"data\n")
+            f.write(b"2\n")
+            f.write(b"'\\u{123}\"1\\x32\\023\n'\n")
+            f.write(b'""\n')
+            f.write(b'"x"\n')
+            f.write(b'data\n')
+            f.write(b'"x"\n')
+            f.write(b"DDEND\n")
+            f.write(b"post\n")
+        t.readTestcase("a.txt")
+        self.assertEqual(t.before, b"pre\nDDBEGIN\ndata\n2\n'")
+        self.assertEqual(t.parts, [b"\\u{123}", b"\"", b"1", b"\\x32", b"\\0", b"2", b"3", b"\n", b"'\n\"\"\n\"", b"x",
+                                   b"\"\ndata\n\"", b"x"])
+        self.assertEqual(t.after, b"\"\nDDEND\npost\n")
 
     def test_symbol(self):
         t = lithium.TestcaseSymbol()

--- a/lithium/test_lithium.py
+++ b/lithium/test_lithium.py
@@ -518,17 +518,20 @@ class TestcaseTests(TestCase):
             f.write(b"DDBEGIN\n")
             f.write(b"data\n")
             f.write(b"2\n")
-            f.write(b"'\\u{123}\"1\\x32\\023\n'\n")
-            f.write(b'""\n')
-            f.write(b'"x"\n')
+            f.write(b"'\\u{123}\"1\\x32\\023\n'\n")  # a str with some escapes
+            f.write(b'""\n')  # empty string
+            f.write(b'"\\u12345"\n')  # another str with the last escape format
             f.write(b'data\n')
-            f.write(b'"x"\n')
+            f.write(b'"x"\n')  # last str
             f.write(b"DDEND\n")
             f.write(b"post\n")
         t.readTestcase("a.txt")
         self.assertEqual(t.before, b"pre\nDDBEGIN\ndata\n2\n'")
-        self.assertEqual(t.parts, [b"\\u{123}", b"\"", b"1", b"\\x32", b"\\0", b"2", b"3", b"\n", b"'\n\"\"\n\"", b"x",
-                                   b"\"\ndata\n\"", b"x"])
+        self.assertEqual(t.parts, [b"\\u{123}", b"\"", b"1", b"\\x32", b"\\0", b"2", b"3", b"\n",  # first str
+                                   b"'\n\"\"\n\"",  # empty string contains no chars, included with in-between data
+                                   b"\\u1234", b"5",  # next str
+                                   b"\"\ndata\n\"",
+                                   b"x"])  # last str
         self.assertEqual(t.after, b"\"\nDDEND\npost\n")
 
     def test_symbol(self):

--- a/lithium/test_lithium.py
+++ b/lithium/test_lithium.py
@@ -23,7 +23,6 @@ import lithium  # pylint: disable=relative-import
 
 log = logging.getLogger("lithium_test")
 logging.basicConfig(level=logging.DEBUG)
-logging.getLogger("flake8").setLevel(logging.WARNING)
 
 
 # python 3 has unlimited precision integers
@@ -512,6 +511,7 @@ class TestcaseTests(TestCase):
         self.assertEqual(t.after, b"\nDDEND\npost\n")
 
     def test_jsstr(self):
+        """Test that the TestcaseJsStr class splits JS strings properly"""
         t = lithium.TestcaseJsStr()
         with open("a.txt", "wb") as f:
             f.write(b"pre\n")
@@ -520,18 +520,18 @@ class TestcaseTests(TestCase):
             f.write(b"2\n")
             f.write(b"'\\u{123}\"1\\x32\\023\n'\n")  # a str with some escapes
             f.write(b'""\n')  # empty string
-            f.write(b'"\\u12345"\n')  # another str with the last escape format
-            f.write(b'data\n')
-            f.write(b'"x"\n')  # last str
+            f.write(b'"\\u12345Xyz"\n')  # another str with the last escape format
+            f.write(b'Data\xFF\n')
+            f.write(b'"x\xFF"\n')  # last str
             f.write(b"DDEND\n")
             f.write(b"post\n")
         t.readTestcase("a.txt")
         self.assertEqual(t.before, b"pre\nDDBEGIN\ndata\n2\n'")
-        self.assertEqual(t.parts, [b"\\u{123}", b"\"", b"1", b"\\x32", b"\\0", b"2", b"3", b"\n",  # first str
+        self.assertEqual(t.parts, [b"\\u{123}", b"\"", b"1", b"\\x32", b"\\0", b"2", b"3", b"\n",  # first JS str
                                    b"'\n\"\"\n\"",  # empty string contains no chars, included with in-between data
-                                   b"\\u1234", b"5",  # next str
-                                   b"\"\ndata\n\"",
-                                   b"x"])  # last str
+                                   b"\\u1234", b"5", b"X", b"y", b"z",  # next JS str
+                                   b"\"\nData\xFF\n\"",
+                                   b"x", b"\xFF"])  # last JS str
         self.assertEqual(t.after, b"\"\nDDEND\npost\n")
 
     def test_symbol(self):


### PR DESCRIPTION
This is like char, but only splits on chars within a JavaScript string. Everything between strings will be treated as a single line for reduction, so this is most useful after a pass of line-reduction for
reducing big string constants.