### PR TITLE
Move file-wide suppressions to be line-specific

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # coding=utf-8
-# flake8: noqa
 # pylint: disable=missing-docstring
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
@@ -9,4 +8,4 @@
 
 from __future__ import absolute_import
 
-from .lithium.lithium import *  # pylint: disable=wildcard-import
+from .lithium.lithium import *  # noqa pylint: disable=wildcard-import

--- a/interestingness/crashes.py
+++ b/interestingness/crashes.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-# pylint: disable=invalid-name,missing-docstring,missing-return-doc,missing-return-type-doc
+# pylint: disable=missing-docstring
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -13,7 +13,8 @@ import optparse  # pylint: disable=deprecated-module
 import timedRun  # pylint: disable=relative-import
 
 
-def parseOptions(arguments):
+def parseOptions(arguments):  # pylint: disable=invalid-name,missing-docstring
+    # pylint: disable=missing-return-doc,missing-return-type-doc
     parser = optparse.OptionParser()
     parser.disable_interspersed_args()
     parser.add_option("-t", "--timeout", type="int", action="store", dest="condTimeout",
@@ -25,11 +26,12 @@ def parseOptions(arguments):
     return options.condTimeout, args
 
 
-def interesting(cliArgs, tempPrefix):
+def interesting(cliArgs, tempPrefix):  # pylint: disable=invalid-name,missing-docstring
+    # pylint: disable=missing-return-doc,missing-return-type-doc
     (timeout, args) = parseOptions(cliArgs)
 
     runinfo = timedRun.timed_run(args, timeout, tempPrefix)
-    timeString = " (%.3f seconds)" % runinfo.elapsedtime
+    timeString = " (%.3f seconds)" % runinfo.elapsedtime  # pylint: disable=invalid-name
     if runinfo.sta == timedRun.CRASHED:
         print("Exit status: " + runinfo.msg + timeString)
         return True

--- a/interestingness/diffTest.py
+++ b/interestingness/diffTest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-# pylint: disable=invalid-name,missing-docstring,missing-return-doc,missing-return-type-doc
+# pylint: disable=invalid-name
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -21,7 +21,8 @@ import optparse  # pylint: disable=deprecated-module
 import timedRun  # pylint: disable=relative-import
 
 
-def parseOptions(arguments):
+def parseOptions(arguments):  # pylint: disable=invalid-name,missing-docstring
+    # pylint: disable=missing-return-doc,missing-return-type-doc
     parser = optparse.OptionParser()
     parser.disable_interspersed_args()
     parser.add_option("-t", "--timeout", type="int", action="store", dest="condTimeout",
@@ -39,11 +40,15 @@ def parseOptions(arguments):
     return options.condTimeout, options.aArgs, options.bArgs, args
 
 
-def interesting(cliArgs, tempPrefix):
-    (timeout, aArgs, bArgs, args) = parseOptions(cliArgs)
+def interesting(cliArgs, tempPrefix):  # pylint: disable=invalid-name,missing-docstring
+    # pylint: disable=missing-return-doc,missing-return-type-doc
+    (timeout, aArgs, bArgs, args) = parseOptions(cliArgs)  # pylint: disable=invalid-name
 
+    # pylint: disable=invalid-name
     aRuninfo = timedRun.timed_run(args[:1] + aArgs + args[1:], timeout, tempPrefix + "-a")
+    # pylint: disable=invalid-name
     bRuninfo = timedRun.timed_run(args[:1] + bArgs + args[1:], timeout, tempPrefix + "-b")
+    # pylint: disable=invalid-name
     timeString = " (1st Run: %.3f seconds) (2nd Run: %.3f seconds)" % (aRuninfo.elapsedtime, bRuninfo.elapsedtime)
 
     if aRuninfo.sta != timedRun.TIMED_OUT and bRuninfo.sta != timedRun.TIMED_OUT:

--- a/interestingness/envVars.py
+++ b/interestingness/envVars.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-# pylint: disable=invalid-name,missing-docstring,missing-param-doc,missing-return-doc,missing-return-type-doc
-# pylint: disable=missing-type-doc
+# pylint: disable=invalid-name,missing-docstring
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -13,22 +12,23 @@ import copy
 import os
 import platform
 
-isLinux = (platform.system() == "Linux")
-isMac = (platform.system() == "Darwin")
-isWin = (platform.system() == "Windows")
+isLinux = (platform.system() == "Linux")  # pylint: disable=invalid-name
+isMac = (platform.system() == "Darwin")  # pylint: disable=invalid-name
+isWin = (platform.system() == "Windows")  # pylint: disable=invalid-name
 
 ENV_PATH_SEPARATOR = ";" if os.name == "nt" else ":"
 
 
-def envWithPath(path, runningEnv=None):
+def envWithPath(path, runningEnv=None):  # pylint: disable=invalid-name,missing-param-doc,missing-return-doc
+    # pylint: disable=missing-return-type-doc,missing-type-doc
     """Append the path to the appropriate library path on various platforms."""
     runningEnv = runningEnv or os.environ
     if isLinux:
-        libPath = "LD_LIBRARY_PATH"
+        libPath = "LD_LIBRARY_PATH"  # pylint: disable=invalid-name
     elif isMac:
-        libPath = "DYLD_LIBRARY_PATH"
+        libPath = "DYLD_LIBRARY_PATH"  # pylint: disable=invalid-name
     elif isWin:
-        libPath = "PATH"
+        libPath = "PATH"  # pylint: disable=invalid-name
 
     env = copy.deepcopy(runningEnv)
     if libPath in env:
@@ -40,7 +40,7 @@ def envWithPath(path, runningEnv=None):
     return env
 
 
-def findLlvmBinPath():
+def findLlvmBinPath():  # pylint: disable=invalid-name,missing-return-doc,missing-return-type-doc
     """Return the path to compiled LLVM binaries, which differs depending on compilation method."""
     if isLinux:
         # Assumes clang was installed through apt-get. Works with version 3.6.2,
@@ -56,7 +56,7 @@ def findLlvmBinPath():
 
     if isMac:
         # Assumes LLVM was installed through Homebrew. Works with at least version 3.6.2.
-        brewLLVMPath = "/usr/local/opt/llvm/bin"
+        brewLLVMPath = "/usr/local/opt/llvm/bin"  # pylint: disable=invalid-name
         if os.path.isdir(brewLLVMPath):
             return brewLLVMPath
 

--- a/interestingness/fileIngredients.py
+++ b/interestingness/fileIngredients.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-# pylint: disable=invalid-name,missing-docstring,missing-return-doc,missing-return-type-doc
+# pylint: disable=invalid-name,missing-docstring
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -11,14 +11,16 @@ from __future__ import print_function
 import re
 
 
-def fileContains(f, s, isRegex, vb=True):
+def fileContains(f, s, isRegex, vb=True):  # pylint: disable=invalid-name,missing-docstring
+    # pylint: disable=missing-return-doc,missing-return-type-doc
     if isRegex:
         return fileContainsRegex(f, re.compile(s, re.MULTILINE), verbose=vb)
     return fileContainsStr(f, s, verbose=vb), s
 
 
-def fileContainsStr(f, s, verbose=True):
-    with open(f, "rb") as g:
+def fileContainsStr(f, s, verbose=True):  # pylint: disable=invalid-name,missing-docstring
+    # pylint: disable=missing-return-doc,missing-return-type-doc
+    with open(f, "rb") as g:  # pylint: disable=invalid-name
         for line in g:
             line = line.strip()
             if not line:
@@ -30,16 +32,17 @@ def fileContainsStr(f, s, verbose=True):
     return False
 
 
-def fileContainsRegex(f, regex, verbose=True):
+def fileContainsRegex(f, regex, verbose=True):  # pylint: disable=invalid-name,missing-docstring
+    # pylint: disable=missing-return-doc,missing-return-type-doc
     # e.g. ~/fuzzing/lithium/lithium.py crashesat --timeout=30
     #       --regex '^#0\s*0x.* in\s*.*(?:\n|\r\n?)#1\s*' ./js --ion -n 735957.js
     # Note that putting "^" and "$" together is unlikely to work.
-    matchedStr = ""
+    matchedStr = ""  # pylint: disable=invalid-name
     found = False
-    with open(f, "rb") as g:
-        foundRegex = regex.search(g.read())
+    with open(f, "rb") as g:  # pylint: disable=invalid-name
+        foundRegex = regex.search(g.read())  # pylint: disable=invalid-name
         if foundRegex:
-            matchedStr = foundRegex.group()
+            matchedStr = foundRegex.group()  # pylint: disable=invalid-name
             if verbose and matchedStr != b"":
                 print("[Found string in: '" + matchedStr.decode("utf-8", errors="replace") + "']", end=" ")
             found = True

--- a/interestingness/fileIngredients.py
+++ b/interestingness/fileIngredients.py
@@ -32,11 +32,12 @@ def fileContainsStr(f, s, verbose=True):  # pylint: disable=invalid-name,missing
     return False
 
 
-def fileContainsRegex(f, regex, verbose=True):  # pylint: disable=invalid-name,missing-docstring
-    # pylint: disable=missing-return-doc,missing-return-type-doc
-    # e.g. ~/fuzzing/lithium/lithium.py crashesat --timeout=30
-    #       --regex '^#0\s*0x.* in\s*.*(?:\n|\r\n?)#1\s*' ./js --ion -n 735957.js
-    # Note that putting "^" and "$" together is unlikely to work.
+def fileContainsRegex(f, regex, verbose=True):  # pylint: disable=invalid-name
+    # pylint: disable=missing-param-doc,missing-return-doc,missing-return-type-doc,missing-type-doc
+    """e.g. ~/fuzzing/lithium/lithium.py crashesat --timeout=30
+     --regex '^#0\\s*0x.* in\\s*.*(?:\\n|\\r\\n?)#1\\s*' ./js --ion -n 735957.js
+     Note that putting "^" and "$" together is unlikely to work."""
+
     matchedStr = ""  # pylint: disable=invalid-name
     found = False
     with open(f, "rb") as g:  # pylint: disable=invalid-name

--- a/interestingness/hangs.py
+++ b/interestingness/hangs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-# pylint: disable=invalid-name,missing-docstring,missing-return-doc,missing-return-type-doc
+# pylint: disable=missing-docstring
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -11,7 +11,8 @@ from __future__ import print_function
 import timedRun  # pylint: disable=relative-import
 
 
-def interesting(args, tempPrefix):
+def interesting(args, tempPrefix):  # pylint: disable=invalid-name,missing-docstring
+    # pylint: disable=missing-return-doc,missing-return-type-doc
     timeout = int(args[0])
 
     runinfo = timedRun.timed_run(args[1:], timeout, tempPrefix)

--- a/interestingness/outputs.py
+++ b/interestingness/outputs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-# pylint: disable=invalid-name,missing-docstring,missing-return-doc,missing-return-type-doc
+# pylint: disable=missing-docstring
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -15,7 +15,8 @@ import fileIngredients  # pylint: disable=relative-import
 import timedRun  # pylint: disable=relative-import
 
 
-def parseOptions(arguments):
+def parseOptions(arguments):  # pylint: disable=invalid-name,missing-docstring
+    # pylint: disable=missing-return-doc,missing-return-type-doc
     parser = optparse.OptionParser()
     parser.disable_interspersed_args()
     parser.add_option("-t", "--timeout", type="int", action="store", dest="condTimeout",
@@ -29,12 +30,13 @@ def parseOptions(arguments):
     return options.condTimeout, options.useRegex, args
 
 
-def interesting(cliArgs, tempPrefix):
-    (timeout, regexEnabled, args) = parseOptions(cliArgs)
+def interesting(cliArgs, tempPrefix):  # pylint: disable=invalid-name,missing-docstring
+    # pylint: disable=missing-return-doc,missing-return-type-doc
+    (timeout, regexEnabled, args) = parseOptions(cliArgs)  # pylint: disable=invalid-name
 
-    searchFor = args[0]
+    searchFor = args[0]  # pylint: disable=invalid-name
     if not isinstance(searchFor, bytes):
-        searchFor = searchFor.encode(sys.getfilesystemencoding())
+        searchFor = searchFor.encode(sys.getfilesystemencoding())  # pylint: disable=invalid-name
 
     runinfo = timedRun.timed_run(args[1:], timeout, tempPrefix)
 

--- a/interestingness/range.py
+++ b/interestingness/range.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # coding=utf-8
-# pylint: disable=invalid-name,missing-return-doc,missing-return-type-doc
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -35,13 +34,14 @@ import optparse  # pylint: disable=deprecated-module
 import os
 import sys
 
-path0 = os.path.dirname(os.path.abspath(__file__))
-path1 = os.path.abspath(os.path.join(path0, os.pardir, 'util'))
+path0 = os.path.dirname(os.path.abspath(__file__))  # pylint: disable=invalid-name
+path1 = os.path.abspath(os.path.join(path0, os.pardir, 'util'))  # pylint: disable=invalid-name
 sys.path.append(path1)
 import ximport  # noqa  pylint: disable=relative-import,wrong-import-position
 
 
-def parseOptions(arguments):  # pylint: disable=missing-docstring
+def parseOptions(arguments):  # pylint: disable=invalid-name,missing-docstring
+    # pylint: disable=missing-return-doc,missing-return-type-doc
     parser = optparse.OptionParser()
     parser.disable_interspersed_args()
     _options, args = parser.parse_args(arguments)
@@ -49,10 +49,11 @@ def parseOptions(arguments):  # pylint: disable=missing-docstring
     return int(args[0]), int(args[1]), args[2:]  # args[0] is minLoopNum, args[1] maxLoopNum
 
 
-def interesting(cliArgs, tempPrefix):  # pylint: disable=missing-docstring
-    (rangeMin, rangeMax, arguments) = parseOptions(cliArgs)
-    conditionScript = ximport.importRelativeOrAbsolute(arguments[0])
-    conditionArgs = arguments[1:]
+def interesting(cliArgs, tempPrefix):  # pylint: disable=invalid-name,missing-docstring
+    # pylint: disable=missing-return-doc,missing-return-type-doc
+    (rangeMin, rangeMax, arguments) = parseOptions(cliArgs)  # pylint: disable=invalid-name
+    conditionScript = ximport.importRelativeOrAbsolute(arguments[0])  # pylint: disable=invalid-name
+    conditionArgs = arguments[1:]  # pylint: disable=invalid-name
 
     if hasattr(conditionScript, "init"):
         conditionScript.init(conditionArgs)
@@ -60,7 +61,7 @@ def interesting(cliArgs, tempPrefix):  # pylint: disable=missing-docstring
     assert (rangeMax - rangeMin) >= 0
     for i in range(rangeMin, rangeMax + 1):
         # This doesn't do anything if RANGENUM is not found.
-        replacedConditionArgs = [s.replace("RANGENUM", str(i)) for s in conditionArgs]
+        replacedConditionArgs = [s.replace("RANGENUM", str(i)) for s in conditionArgs]  # pylint: disable=invalid-name
         print("Range number %d:" % i, end=" ")
         if conditionScript.interesting(replacedConditionArgs, tempPrefix):
             return True

--- a/interestingness/timedRun.py
+++ b/interestingness/timedRun.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-# pylint: disable=invalid-name,missing-docstring,missing-param-doc,missing-raises-doc,missing-return-doc
-# pylint: disable=missing-return-type-doc,missing-type-doc
+# pylint: disable=invalid-name,missing-docstring
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -15,8 +14,8 @@ import subprocess
 import sys
 import time
 
-path0 = os.path.dirname(os.path.abspath(__file__))
-path1 = os.path.abspath(os.path.join(path0, os.pardir, 'interestingness'))
+path0 = os.path.dirname(os.path.abspath(__file__))  # pylint: disable=invalid-name
+path1 = os.path.abspath(os.path.join(path0, os.pardir, 'interestingness'))  # pylint: disable=invalid-name
 sys.path.append(path1)
 import envVars  # noqa  pylint: disable=relative-import,wrong-import-position
 
@@ -25,22 +24,24 @@ ASAN_EXIT_CODE = 77
 (CRASHED, TIMED_OUT, NORMAL, ABNORMAL, NONE) = range(5)
 
 
-def getSignalName(num, default=None):
-    for p in dir(signal):
+def getSignalName(num, default=None):  # pylint: disable=invalid-name,missing-docstring
+    # pylint: disable=missing-return-doc,missing-return-type-doc
+    for p in dir(signal):  # pylint: disable=invalid-name
         if p.startswith("SIG") and not p.startswith("SIG_"):
             if getattr(signal, p) == num:
                 return p
     return default
 
 
-class rundata(object):  # pylint: disable=too-few-public-methods,too-many-instance-attributes
+class rundata(object):  # pylint: disable=invalid-name,missing-param-doc,missing-type-doc
+    # pylint: disable=too-few-public-methods,too-many-instance-attributes
     """Define struct that contains data from a process that has already ended."""
 
-    def __init__(self,  # pylint: disable=too-many-arguments
+    def __init__(self,  # pylint: disable=missing-param-doc,missing-type-doc,too-many-arguments
                  sta, rc, msg, elapsedtime, killed, pid, out, err):
         """Initialize with given parameters."""
         self.sta = sta
-        self.rc = rc
+        self.rc = rc  # pylint: disable=invalid-name
         self.msg = msg
         self.elapsedtime = elapsedtime
         self.killed = killed
@@ -49,7 +50,7 @@ class rundata(object):  # pylint: disable=too-few-public-methods,too-many-instan
         self.err = err
 
 
-def xpkill(p):
+def xpkill(p):  # pylint: disable=invalid-name,missing-param-doc,missing-type-doc
     """Based on mozilla-central/source/build/automation.py.in ."""
     try:
         p.kill()
@@ -64,8 +65,8 @@ def xpkill(p):
                     p.kill()  # Re-verify that the process is really killed.
 
 
-def makeEnv(binPath):
-    shellIsDeterministic = "-dm-" in binPath
+def makeEnv(binPath):  # pylint: disable=invalid-name,missing-docstring,missing-return-doc,missing-return-type-doc
+    shellIsDeterministic = "-dm-" in binPath  # pylint: disable=invalid-name
     # Total hack to make this not rely on queryBuildConfiguration in the funfuzz repository.
     # We need this so releng machines (which work off downloaded shells that are in build/dist/js),
     # do not compile LLVM.
@@ -80,15 +81,16 @@ def makeEnv(binPath):
     return env
 
 
-def timed_run(commandWithArgs,  # pylint: disable=too-complex,too-many-branches,too-many-locals,too-many-statements
-              timeout, logPrefix, inp=None, preexec_fn=None):
+def timed_run(commandWithArgs, timeout, logPrefix, inp=None, preexec_fn=None):  # pylint: disable=invalid-name
+    # pylint: disable=missing-param-doc,missing-raises-doc,missing-return-doc,missing-return-type-doc,missing-type-doc
+    # pylint: disable=too-complex,too-many-branches,too-many-locals,too-many-statements
     """If logPrefix is None, uses pipes instead of files for all output."""
     if not isinstance(commandWithArgs, list):
         raise TypeError("commandWithArgs should be a list (of strings).")
     if not isinstance(timeout, int):
         raise TypeError("timeout should be an int.")
 
-    useLogFiles = isinstance(logPrefix, str)
+    useLogFiles = isinstance(logPrefix, str)  # pylint: disable=invalid-name
 
     commandWithArgs[0] = os.path.expanduser(commandWithArgs[0])
     progname = commandWithArgs[0].split(os.path.sep)[-1]
@@ -96,8 +98,8 @@ def timed_run(commandWithArgs,  # pylint: disable=too-complex,too-many-branches,
     starttime = time.time()
 
     if useLogFiles:
-        childStdOut = open(logPrefix + "-out.txt", "w")
-        childStdErr = open(logPrefix + "-err.txt", "w")
+        childStdOut = open(logPrefix + "-out.txt", "w")  # pylint: disable=invalid-name
+        childStdErr = open(logPrefix + "-err.txt", "w")  # pylint: disable=invalid-name
 
     try:
         child = subprocess.Popen(
@@ -109,7 +111,7 @@ def timed_run(commandWithArgs,  # pylint: disable=too-complex,too-many-branches,
             env=makeEnv(commandWithArgs[0]),
             preexec_fn=preexec_fn
         )
-    except OSError as e:
+    except OSError as e:  # pylint: disable=invalid-name
         print("Tried to run:")
         print("  %r" % commandWithArgs)
         print("but got this error:")
@@ -133,7 +135,7 @@ def timed_run(commandWithArgs,  # pylint: disable=too-complex,too-many-branches,
 
     # This part is a bit like subprocess.communicate, but with a timeout
     while 1:
-        rc = child.poll()
+        rc = child.poll()  # pylint: disable=invalid-name
         elapsedtime = time.time() - starttime
         if rc is None:
             if elapsedtime > timeout and not killed:

--- a/interestingness/ximport.py
+++ b/interestingness/ximport.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # coding=utf-8
-# pylint: disable=invalid-name,missing-return-doc,missing-return-type-doc
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -14,16 +13,17 @@ import logging
 import os
 import sys
 
-log = logging.getLogger("lithium")
+log = logging.getLogger("lithium")  # pylint: disable=invalid-name
 
 
-def importRelativeOrAbsolute(f):  # pylint: disable=missing-docstring
+def importRelativeOrAbsolute(f):  # pylint: disable=invalid-name,missing-docstring
+    # pylint: disable=missing-return-doc,missing-return-type-doc
     # maybe there's a way to do this more sanely with the |imp| module...
     if f.endswith(".py"):
         f = f[:-3]
     if f.endswith(".pyc"):
         f = f[:-4]
-    p, f = os.path.split(f)
+    p, f = os.path.split(f)  # pylint: disable=invalid-name
     if p:
         # Add the path part of the given filename to the import path
         sys.path.append(p)
@@ -32,7 +32,7 @@ def importRelativeOrAbsolute(f):  # pylint: disable=missing-docstring
         sys.path.append(".")
     try:
         module = __import__(f)
-    except ImportError as e:
+    except ImportError as e:  # pylint: disable=invalid-name
         log.error("Failed to import: " + f)
         log.error("From: " + __file__)
         log.error(e)

--- a/interestingness/ximport.py
+++ b/interestingness/ximport.py
@@ -16,8 +16,10 @@ import sys
 log = logging.getLogger("lithium")  # pylint: disable=invalid-name
 
 
-def importRelativeOrAbsolute(f):  # pylint: disable=invalid-name,missing-docstring
-    # pylint: disable=missing-return-doc,missing-return-type-doc
+def importRelativeOrAbsolute(f):  # pylint: disable=invalid-name
+    # pylint: disable=missing-param-doc,missing-raises-doc,missing-return-doc,missing-return-type-doc,missing-type-doc
+    """Import an interestingness test given a full path or a filename."""
+
     # maybe there's a way to do this more sanely with the |imp| module...
     if f.endswith(".py"):
         f = f[:-3]

--- a/lithium/examples/arithmetic/product_divides.py
+++ b/lithium/examples/arithmetic/product_divides.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # coding=utf-8
-# pylint: disable=missing-param-doc,missing-return-doc,missing-return-type-doc,missing-type-doc
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -14,7 +13,8 @@ e.g. lithium product_divides 35 11.txt
 import sys
 
 
-def interesting(args, _temp_prefix):
+def interesting(args, _temp_prefix):  # pylint: disable=missing-param-doc,missing-return-doc
+    # pylint: disable=missing-return-type-doc,missing-type-doc
     """Simple version for testing
     """
     mod = int(args[0])

--- a/lithium/lithium.py
+++ b/lithium/lithium.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # coding=utf-8
-# pylint: disable=invalid-name,missing-docstring,missing-param-doc,missing-return-doc,missing-return-type-doc
-# pylint: disable=missing-type-doc,too-many-lines,too-many-statements
+# pylint: disable=missing-docstring
+# pylint: disable=too-many-lines
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -14,10 +14,10 @@ import re
 import sys
 import time
 
-log = logging.getLogger("lithium")
+log = logging.getLogger("lithium")  # pylint: disable=invalid-name
 
 
-class LithiumError(Exception):
+class LithiumError(Exception):  # pylint: disable=missing-docstring
     pass
 
 
@@ -35,7 +35,7 @@ class Testcase(object):
         self.filename = None
         self.extension = None
 
-    def copy(self):
+    def copy(self):  # pylint: disable=missing-docstring,missing-return-doc,missing-return-type-doc
         new = type(self)()
 
         new.before = self.before
@@ -47,21 +47,21 @@ class Testcase(object):
 
         return new
 
-    def readTestcase(self, filename):
-        hasDDSection = False
+    def readTestcase(self, filename):  # pylint: disable=invalid-name,missing-docstring
+        hasDDSection = False  # pylint: disable=invalid-name
 
         self.__init__()
         self.filename = filename
         self.extension = os.path.splitext(self.filename)[1]
 
-        with open(self.filename, "rb") as f:
+        with open(self.filename, "rb") as f:  # pylint: disable=invalid-name
             # Determine whether the f has a DDBEGIN..DDEND section.
             for line in f:
                 if line.find(b"DDEND") != -1:
                     raise LithiumError("The testcase (%s) has a line containing 'DDEND' "
                                        "without a line containing 'DDBEGIN' before it." % self.filename)
                 if line.find(b"DDBEGIN") != -1:
-                    hasDDSection = True
+                    hasDDSection = True  # pylint: disable=invalid-name
                     break
 
             f.seek(0)
@@ -77,7 +77,7 @@ class Testcase(object):
                 for line in f:
                     self.readTestcaseLine(line)
 
-    def readTestcaseWithDDSection(self, f):
+    def readTestcaseWithDDSection(self, f):  # pylint: disable=invalid-name,missing-docstring
         for line in f:
             self.before += line
             if line.find(b"DDBEGIN") != -1:
@@ -95,14 +95,14 @@ class Testcase(object):
         for line in f:
             self.after += line
 
-    def readTestcaseLine(self, line):
+    def readTestcaseLine(self, line):  # pylint: disable=invalid-name,missing-docstring
         raise NotImplementedError()
 
-    def writeTestcase(self, filename=None):
+    def writeTestcase(self, filename=None):  # pylint: disable=invalid-name,missing-docstring
         raise NotImplementedError()
 
 
-class TestcaseLine(Testcase):
+class TestcaseLine(Testcase):  # pylint: disable=missing-docstring
     atom = "line"
 
     def readTestcaseLine(self, line):
@@ -111,13 +111,13 @@ class TestcaseLine(Testcase):
     def writeTestcase(self, filename=None):
         if filename is None:
             filename = self.filename
-        with open(filename, "wb") as f:
+        with open(filename, "wb") as f:  # pylint: disable=invalid-name
             f.write(self.before)
             f.writelines(self.parts)
             f.write(self.after)
 
 
-class TestcaseChar(TestcaseLine):
+class TestcaseChar(TestcaseLine):  # pylint: disable=missing-docstring
     atom = "char"
 
     def readTestcaseWithDDSection(self, f):
@@ -200,7 +200,7 @@ class TestcaseJsStr(TestcaseChar):
             self.parts.append(line[last:])
 
 
-class TestcaseSymbol(TestcaseLine):
+class TestcaseSymbol(TestcaseLine):  # pylint: disable=missing-docstring
     atom = "symbol-delimiter"
     DEFAULT_CUT_AFTER = b"?=;{["
     DEFAULT_CUT_BEFORE = b"]}:"
@@ -208,8 +208,8 @@ class TestcaseSymbol(TestcaseLine):
     def __init__(self):
         TestcaseLine.__init__(self)
 
-        self.cutAfter = self.DEFAULT_CUT_AFTER
-        self.cutBefore = self.DEFAULT_CUT_BEFORE
+        self.cutAfter = self.DEFAULT_CUT_AFTER  # pylint: disable=invalid-name
+        self.cutBefore = self.DEFAULT_CUT_BEFORE  # pylint: disable=invalid-name
 
     def readTestcaseLine(self, line):
         cutter = (b"[" + self.cutBefore + b"]?" +
@@ -227,36 +227,36 @@ class Strategy(object):
     to minimize the testcase.
     """
 
-    def addArgs(self, parser):
+    def addArgs(self, parser):  # pylint: disable=invalid-name,missing-docstring
         pass
 
-    def processArgs(self, parser, args):
+    def processArgs(self, parser, args):  # pylint: disable=invalid-name,missing-docstring
         pass
 
-    def main(self, testcase, interesting, tempFilename):
+    def main(self, testcase, interesting, tempFilename):  # pylint: disable=invalid-name,missing-docstring
         raise NotImplementedError()
 
 
-class CheckOnly(Strategy):
+class CheckOnly(Strategy):  # pylint: disable=missing-docstring
     name = "check-only"
 
-    def main(self, testcase, interesting, tempFilename):
-        r = interesting(testcase, writeIt=False)
+    def main(self, testcase, interesting, tempFilename):  # pylint: disable=missing-return-doc,missing-return-type-doc
+        r = interesting(testcase, writeIt=False)  # pylint: disable=invalid-name
         log.info("Lithium result: %s", ("interesting." if r else "not interesting."))
         return 0
 
 
-class Minimize(Strategy):
+class Minimize(Strategy):  # pylint: disable=missing-docstring
     name = "minimize"
 
     def __init__(self):
-        self.minimizeRepeat = "last"
-        self.minimizeMin = 1
-        self.minimizeMax = pow(2, 30)
-        self.minimizeChunkStart = 0
-        self.minimizeChunkSize = None
-        self.minimizeRepeatFirstRound = False
-        self.stopAfterTime = None
+        self.minimizeRepeat = "last"  # pylint: disable=invalid-name
+        self.minimizeMin = 1  # pylint: disable=invalid-name
+        self.minimizeMax = pow(2, 30)  # pylint: disable=invalid-name
+        self.minimizeChunkStart = 0  # pylint: disable=invalid-name
+        self.minimizeChunkSize = None  # pylint: disable=invalid-name
+        self.minimizeRepeatFirstRound = False  # pylint: disable=invalid-name
+        self.stopAfterTime = None  # pylint: disable=invalid-name
 
     def addArgs(self, parser):
         grp_add = parser.add_argument_group(description="Additional options for the %s strategy" % self.name)
@@ -307,7 +307,7 @@ class Minimize(Strategy):
         if not isPowerOfTwo(self.minimizeMin) or not isPowerOfTwo(self.minimizeMax):
             parser.error("Min/Max must be powers of two.")
 
-    def main(self, testcase, interesting, tempFilename):
+    def main(self, testcase, interesting, tempFilename):  # pylint: disable=missing-return-doc,missing-return-type-doc
         log.info("The original testcase has %s.", quantity(len(testcase.parts), testcase.atom))
         log.info("Checking that the original testcase is 'interesting'...")
         if not interesting(testcase, writeIt=False):
@@ -319,8 +319,8 @@ class Minimize(Strategy):
 
         testcase.writeTestcase(tempFilename("original", False))
 
-        origNumParts = len(testcase.parts)
-        result, anySingle, testcase = self.run(testcase, interesting, tempFilename)
+        origNumParts = len(testcase.parts)  # pylint: disable=invalid-name
+        result, anySingle, testcase = self.run(testcase, interesting, tempFilename)  # pylint: disable=invalid-name
 
         testcase.writeTestcase()
 
@@ -346,11 +346,13 @@ class Minimize(Strategy):
     #   interesting(a);
     #   c = compute();   <-- !!!
     #
-    def run(self, testcase, interesting, tempFilename):
+    def run(self, testcase, interesting, tempFilename):  # pylint: disable=invalid-name,missing-docstring
+        # pylint: disable=missing-return-doc,missing-return-type-doc
+        # pylint: disable=invalid-name
         chunkSize = min(self.minimizeMax, largestPowerOfTwoSmallerThan(len(testcase.parts)))
-        finalChunkSize = min(chunkSize, max(self.minimizeMin, 1))
-        chunkStart = self.minimizeChunkStart
-        anyChunksRemoved = self.minimizeRepeatFirstRound
+        finalChunkSize = min(chunkSize, max(self.minimizeMin, 1))  # pylint: disable=invalid-name
+        chunkStart = self.minimizeChunkStart  # pylint: disable=invalid-name
+        anyChunksRemoved = self.minimizeRepeatFirstRound  # pylint: disable=invalid-name
 
         while True:
             if self.stopAfterTime and time.time() > self.stopAfterTime:
@@ -394,7 +396,7 @@ class Minimize(Strategy):
         return 0, (chunkSize == 1 and not anyChunksRemoved and self.minimizeRepeat != "never"), testcase
 
 
-class MinimizeSurroundingPairs(Minimize):
+class MinimizeSurroundingPairs(Minimize):  # pylint: disable=missing-docstring
     name = "minimize-around"
 
     # This strategy attempts to remove pairs of chunks which might be surrounding
@@ -408,9 +410,10 @@ class MinimizeSurroundingPairs(Minimize):
     #      a = bar(b);      <-- !!!
     #   }
     #
-    def run(self, testcase, interesting, tempFilename):
+    def run(self, testcase, interesting, tempFilename):  # pylint: disable=missing-return-doc,missing-return-type-doc
+        # pylint: disable=invalid-name
         chunkSize = min(self.minimizeMax, largestPowerOfTwoSmallerThan(len(testcase.parts)))
-        finalChunkSize = max(self.minimizeMin, 1)
+        finalChunkSize = max(self.minimizeMin, 1)  # pylint: disable=invalid-name
 
         while 1:
             anyChunksRemoved, testcase = self.tryRemovingChunks(chunkSize, testcase, interesting, tempFilename)
@@ -430,7 +433,8 @@ class MinimizeSurroundingPairs(Minimize):
         return 0, (finalChunkSize == 1 and self.minimizeRepeat != "never"), testcase
 
     @staticmethod
-    def list_rindex(l, p, e):
+    def list_rindex(l, p, e):  # pylint: disable=invalid-name,missing-docstring
+        # pylint: disable=missing-return-doc,missing-return-type-doc
         if p < 0 or p > len(l):
             raise ValueError("%s is not in list" % e)
         for index, item in enumerate(reversed(l[:p])):
@@ -439,23 +443,26 @@ class MinimizeSurroundingPairs(Minimize):
         raise ValueError("%s is not in list" % e)
 
     @staticmethod
-    def list_nindex(l, p, e):
+    def list_nindex(l, p, e):  # pylint: disable=invalid-name,missing-docstring
+        # pylint: disable=missing-return-doc,missing-return-type-doc
         if p + 1 >= len(l):
             raise ValueError("%s is not in list" % e)
         return l[(p + 1):].index(e) + (p + 1)
 
-    def tryRemovingChunks(self, chunkSize, testcase, interesting, tempFilename):  # pylint: disable=too-many-locals
+    def tryRemovingChunks(self, chunkSize, testcase, interesting, tempFilename):  # pylint: disable=invalid-name
+        # pylint: disable=missing-param-doc,missing-return-doc,missing-return-type-doc,missing-type-doc
+        # pylint: disable=too-many-locals,too-many-statements
         """Make a single run through the testcase, trying to remove chunks of size chunkSize.
 
         Returns True iff any chunks were removed."""
 
         summary = ""
 
-        chunksRemoved = 0
-        atomsRemoved = 0
+        chunksRemoved = 0  # pylint: disable=invalid-name
+        atomsRemoved = 0  # pylint: disable=invalid-name
 
-        atomsInitial = len(testcase.parts)
-        numChunks = divideRoundingUp(len(testcase.parts), chunkSize)
+        atomsInitial = len(testcase.parts)  # pylint: disable=invalid-name
+        numChunks = divideRoundingUp(len(testcase.parts), chunkSize)  # pylint: disable=invalid-name
 
         # Not enough chunks to remove surrounding blocks.
         if numChunks < 3:
@@ -464,61 +471,61 @@ class MinimizeSurroundingPairs(Minimize):
         log.info("Starting a round with chunks of %s.", quantity(chunkSize, testcase.atom))
 
         summary = ["S" for _ in range(numChunks)]
-        chunkStart = chunkSize
-        beforeChunkIdx = 0
-        keepChunkIdx = 1
-        afterChunkIdx = 2
+        chunkStart = chunkSize  # pylint: disable=invalid-name
+        beforeChunkIdx = 0  # pylint: disable=invalid-name
+        keepChunkIdx = 1  # pylint: disable=invalid-name
+        afterChunkIdx = 2  # pylint: disable=invalid-name
 
         try:
             while chunkStart + chunkSize < len(testcase.parts):
-                chunkBefStart = max(0, chunkStart - chunkSize)
-                chunkBefEnd = chunkStart
-                chunkAftStart = min(len(testcase.parts), chunkStart + chunkSize)
-                chunkAftEnd = min(len(testcase.parts), chunkAftStart + chunkSize)
+                chunkBefStart = max(0, chunkStart - chunkSize)  # pylint: disable=invalid-name
+                chunkBefEnd = chunkStart  # pylint: disable=invalid-name
+                chunkAftStart = min(len(testcase.parts), chunkStart + chunkSize)  # pylint: disable=invalid-name
+                chunkAftEnd = min(len(testcase.parts), chunkAftStart + chunkSize)  # pylint: disable=invalid-name
                 description = "chunk #%d & #%d of %d chunks of size %d" % (
                     beforeChunkIdx, afterChunkIdx, numChunks, chunkSize)
 
-                testcaseSuggestion = testcase.copy()
+                testcaseSuggestion = testcase.copy()  # pylint: disable=invalid-name
                 testcaseSuggestion.parts = (testcaseSuggestion.parts[:chunkBefStart] +
                                             testcaseSuggestion.parts[chunkBefEnd:chunkAftStart] +
                                             testcaseSuggestion.parts[chunkAftEnd:])
                 if interesting(testcaseSuggestion):
                     testcase = testcaseSuggestion
                     log.info("Yay, reduced it by removing %s :)", description)
-                    chunksRemoved += 2
-                    atomsRemoved += (chunkBefEnd - chunkBefStart)
-                    atomsRemoved += (chunkAftEnd - chunkAftStart)
+                    chunksRemoved += 2  # pylint: disable=invalid-name
+                    atomsRemoved += (chunkBefEnd - chunkBefStart)  # pylint: disable=invalid-name
+                    atomsRemoved += (chunkAftEnd - chunkAftStart)  # pylint: disable=invalid-name
                     summary[beforeChunkIdx] = "-"
                     summary[afterChunkIdx] = "-"
                     # The start is now sooner since we remove the chunk which was before this one.
-                    chunkStart -= chunkSize
+                    chunkStart -= chunkSize  # pylint: disable=invalid-name
                     try:
                         # Try to keep removing surrounding chunks of the same part.
-                        beforeChunkIdx = self.list_rindex(summary, keepChunkIdx, "S")
+                        beforeChunkIdx = self.list_rindex(summary, keepChunkIdx, "S")  # pylint: disable=invalid-name
                     except ValueError:
                         # There is no more survinving block on the left-hand-side of
                         # the current chunk, shift everything by one surviving
                         # block. Any ValueError from here means that there is no
                         # longer enough chunk.
-                        beforeChunkIdx = keepChunkIdx
-                        keepChunkIdx = self.list_nindex(summary, keepChunkIdx, "S")
-                        chunkStart += chunkSize
+                        beforeChunkIdx = keepChunkIdx  # pylint: disable=invalid-name
+                        keepChunkIdx = self.list_nindex(summary, keepChunkIdx, "S")  # pylint: disable=invalid-name
+                        chunkStart += chunkSize  # pylint: disable=invalid-name
                 else:
                     log.info("Removing %s made the file 'uninteresting'.", description)
                     # Shift chunk indexes, and seek the next surviving chunk. ValueError
                     # from here means that there is no longer enough chunks.
-                    beforeChunkIdx = keepChunkIdx
-                    keepChunkIdx = afterChunkIdx
-                    chunkStart += chunkSize
+                    beforeChunkIdx = keepChunkIdx  # pylint: disable=invalid-name
+                    keepChunkIdx = afterChunkIdx  # pylint: disable=invalid-name
+                    chunkStart += chunkSize  # pylint: disable=invalid-name
 
-                afterChunkIdx = self.list_nindex(summary, keepChunkIdx, "S")
+                afterChunkIdx = self.list_nindex(summary, keepChunkIdx, "S")  # pylint: disable=invalid-name
 
         except ValueError:
             # This is a valid loop exit point.
-            chunkStart = len(testcase.parts)
+            chunkStart = len(testcase.parts)  # pylint: disable=invalid-name
 
-        atomsSurviving = atomsInitial - atomsRemoved
-        printableSummary = " ".join(
+        atomsSurviving = atomsInitial - atomsRemoved  # pylint: disable=invalid-name
+        printableSummary = " ".join(  # pylint: disable=invalid-name
             "".join(summary[(2 * i):min(2 * (i + 1), numChunks + 1)]) for i in range(numChunks // 2 + numChunks % 2))
         log.info("")
         log.info("Done with a round of chunk size %d!", chunkSize)
@@ -536,7 +543,7 @@ class MinimizeSurroundingPairs(Minimize):
         return bool(chunksRemoved), testcase
 
 
-class MinimizeBalancedPairs(MinimizeSurroundingPairs):
+class MinimizeBalancedPairs(MinimizeSurroundingPairs):  # pylint: disable=missing-docstring
     name = "minimize-balanced"
 
     # This strategy attempts to remove balanced chunks which might be surrounding
@@ -556,22 +563,24 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
     #
 
     @staticmethod
-    def list_fiveParts(lst, step, f, s, t):
+    def list_fiveParts(lst, step, f, s, t):  # pylint: disable=invalid-name,missing-docstring
+        # pylint: disable=missing-return-doc,missing-return-type-doc
         return (lst[:f], lst[f:s], lst[s:(s + step)], lst[(s + step):(t + step)], lst[(t + step):])
 
-    def tryRemovingChunks(self,  # pylint: disable=too-complex,too-many-branches,too-many-locals
-                          chunkSize, testcase, interesting, tempFilename):
+    def tryRemovingChunks(self, chunkSize, testcase, interesting, tempFilename):
+        # pylint: disable=missing-param-doc,missing-return-doc,missing-return-type-doc,missing-type-doc
+        # pylint: disable=too-many-branches,too-complex,too-many-locals,too-many-statements
         """Make a single run through the testcase, trying to remove chunks of size chunkSize.
 
         Returns True iff any chunks were removed."""
 
         summary = ""
 
-        chunksRemoved = 0
-        atomsRemoved = 0
+        chunksRemoved = 0  # pylint: disable=invalid-name
+        atomsRemoved = 0  # pylint: disable=invalid-name
 
-        atomsInitial = len(testcase.parts)
-        numChunks = divideRoundingUp(len(testcase.parts), chunkSize)
+        atomsInitial = len(testcase.parts)  # pylint: disable=invalid-name
+        numChunks = divideRoundingUp(len(testcase.parts), chunkSize)  # pylint: disable=invalid-name
 
         # Not enough chunks to remove surrounding blocks.
         if numChunks < 2:
@@ -583,8 +592,8 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
         curly = [(testcase.parts[i].count(b"{") - testcase.parts[i].count(b"}")) for i in range(numChunks)]
         square = [(testcase.parts[i].count(b"[") - testcase.parts[i].count(b"]")) for i in range(numChunks)]
         normal = [(testcase.parts[i].count(b"(") - testcase.parts[i].count(b")")) for i in range(numChunks)]
-        chunkStart = 0
-        lhsChunkIdx = 0
+        chunkStart = 0  # pylint: disable=invalid-name
+        lhsChunkIdx = 0  # pylint: disable=invalid-name
 
         try:
             while chunkStart < len(testcase.parts):
@@ -595,39 +604,39 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
                 assert summary[:lhsChunkIdx].count("S") * chunkSize == chunkStart, (
                     "the chunkStart should correspond to the lhsChunkIdx modulo the removed chunks.")
 
-                chunkLhsStart = chunkStart
-                chunkLhsEnd = min(len(testcase.parts), chunkLhsStart + chunkSize)
+                chunkLhsStart = chunkStart  # pylint: disable=invalid-name
+                chunkLhsEnd = min(len(testcase.parts), chunkLhsStart + chunkSize)  # pylint: disable=invalid-name
 
-                nCurly = curly[lhsChunkIdx]
-                nSquare = square[lhsChunkIdx]
-                nNormal = normal[lhsChunkIdx]
+                nCurly = curly[lhsChunkIdx]  # pylint: disable=invalid-name
+                nSquare = square[lhsChunkIdx]  # pylint: disable=invalid-name
+                nNormal = normal[lhsChunkIdx]  # pylint: disable=invalid-name
 
                 # If the chunk is already balanced, try to remove it.
                 if not (nCurly or nSquare or nNormal):
-                    testcaseSuggestion = testcase.copy()
+                    testcaseSuggestion = testcase.copy()  # pylint: disable=invalid-name
                     testcaseSuggestion.parts = (testcaseSuggestion.parts[:chunkLhsStart] +
                                                 testcaseSuggestion.parts[chunkLhsEnd:])
                     if interesting(testcaseSuggestion):
                         testcase = testcaseSuggestion
                         log.info("Yay, reduced it by removing %s :)", description)
-                        chunksRemoved += 1
-                        atomsRemoved += (chunkLhsEnd - chunkLhsStart)
+                        chunksRemoved += 1  # pylint: disable=invalid-name
+                        atomsRemoved += (chunkLhsEnd - chunkLhsStart)  # pylint: disable=invalid-name
                         summary[lhsChunkIdx] = "-"
                     else:
                         log.info("Removing %s made the file 'uninteresting'.", description)
-                        chunkStart += chunkSize
-                    lhsChunkIdx = self.list_nindex(summary, lhsChunkIdx, "S")
+                        chunkStart += chunkSize  # pylint: disable=invalid-name
+                    lhsChunkIdx = self.list_nindex(summary, lhsChunkIdx, "S")  # pylint: disable=invalid-name
                     continue
 
                 # Otherwise look for the corresponding chunk.
-                rhsChunkIdx = lhsChunkIdx
+                rhsChunkIdx = lhsChunkIdx  # pylint: disable=invalid-name
                 for item in summary[(lhsChunkIdx + 1):]:
-                    rhsChunkIdx += 1
+                    rhsChunkIdx += 1  # pylint: disable=invalid-name
                     if item != "S":
                         continue
-                    nCurly += curly[rhsChunkIdx]
-                    nSquare += square[rhsChunkIdx]
-                    nNormal += normal[rhsChunkIdx]
+                    nCurly += curly[rhsChunkIdx]  # pylint: disable=invalid-name
+                    nSquare += square[rhsChunkIdx]  # pylint: disable=invalid-name
+                    nNormal += normal[rhsChunkIdx]  # pylint: disable=invalid-name
                     if nCurly < 0 or nSquare < 0 or nNormal < 0:
                         break
                     if not (nCurly or nSquare or nNormal):
@@ -636,14 +645,15 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
                 # If we have no match, then just skip this pair of chunks.
                 if nCurly or nSquare or nNormal:
                     log.info("Skipping %s because it is 'uninteresting'.", description)
-                    chunkStart += chunkSize
-                    lhsChunkIdx = self.list_nindex(summary, lhsChunkIdx, "S")
+                    chunkStart += chunkSize  # pylint: disable=invalid-name
+                    lhsChunkIdx = self.list_nindex(summary, lhsChunkIdx, "S")  # pylint: disable=invalid-name
                     continue
 
                 # Otherwise we do have a match and we check if this is interesting to remove both.
+                # pylint: disable=invalid-name
                 chunkRhsStart = chunkLhsStart + chunkSize * summary[lhsChunkIdx:rhsChunkIdx].count("S")
-                chunkRhsStart = min(len(testcase.parts), chunkRhsStart)
-                chunkRhsEnd = min(len(testcase.parts), chunkRhsStart + chunkSize)
+                chunkRhsStart = min(len(testcase.parts), chunkRhsStart)  # pylint: disable=invalid-name
+                chunkRhsEnd = min(len(testcase.parts), chunkRhsStart + chunkSize)  # pylint: disable=invalid-name
 
                 description = "chunk #%d & #%d of %d chunks of size %d" % (
                     lhsChunkIdx, rhsChunkIdx, numChunks, chunkSize)
@@ -751,10 +761,10 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
 
         except ValueError:
             # This is a valid loop exit point.
-            chunkStart = len(testcase.parts)
+            chunkStart = len(testcase.parts)  # pylint: disable=invalid-name
 
-        atomsSurviving = atomsInitial - atomsRemoved
-        printableSummary = " ".join(
+        atomsSurviving = atomsInitial - atomsRemoved  # pylint: disable=invalid-name
+        printableSummary = " ".join(  # pylint: disable=invalid-name
             "".join(summary[(2 * i):min(2 * (i + 1), numChunks + 1)]) for i in range(numChunks // 2 + numChunks % 2))
         log.info("")
         log.info("Done with a round of chunk size %d!", chunkSize)
@@ -772,7 +782,7 @@ class MinimizeBalancedPairs(MinimizeSurroundingPairs):
         return bool(chunksRemoved), testcase
 
 
-class ReplacePropertiesByGlobals(Minimize):
+class ReplacePropertiesByGlobals(Minimize):  # pylint: disable=missing-docstring
     name = "replace-properties-by-globals"
 
     # This strategy attempts to remove members, such that other strategies can
@@ -802,7 +812,8 @@ class ReplacePropertiesByGlobals(Minimize):
     #     return list.pop();
     #   }
     #
-    def run(self, testcase, interesting, tempFilename):
+    def run(self, testcase, interesting, tempFilename):  # pylint: disable=missing-return-doc,missing-return-type-doc
+        # pylint: disable=invalid-name
         chunkSize = min(self.minimizeMax, 2 * largestPowerOfTwoSmallerThan(len(testcase.parts)))
         finalChunkSize = max(self.minimizeMin, 1)
 
@@ -832,8 +843,9 @@ class ReplacePropertiesByGlobals(Minimize):
 
         return 0, (finalChunkSize == 1 and self.minimizeRepeat != "never"), testcase
 
-    def tryMakingGlobals(self,  # pylint: disable=too-complex,too-many-arguments,too-many-branches,too-many-locals
-                         chunkSize, numChars, testcase, interesting, tempFilename):
+    def tryMakingGlobals(self, chunkSize, numChars, testcase, interesting, tempFilename):
+        # pylint: disable=invalid-name,missing-param-doc,missing-return-doc,missing-return-type-doc,missing-type-doc
+        # pylint: disable=too-many-arguments,too-many-branches,too-complex,too-many-locals
         """Make a single run through the testcase, trying to remove chunks of size chunkSize.
 
         Returns True iff any chunks were removed."""
@@ -915,7 +927,7 @@ class ReplacePropertiesByGlobals(Minimize):
         return numRemovedChars, testcase
 
 
-class ReplaceArgumentsByGlobals(Minimize):
+class ReplaceArgumentsByGlobals(Minimize):  # pylint: disable=missing-docstring
     name = "replace-arguments-by-globals"
 
     # This strategy attempts to replace arguments by globals, for each named
@@ -939,11 +951,12 @@ class ReplaceArgumentsByGlobals(Minimize):
     #
     # The next logical step is inlining the body of the function at the call site.
     #
-    def run(self, testcase, interesting, tempFilename):
-        roundNum = 0
+    def run(self, testcase, interesting, tempFilename):  # pylint: disable=missing-return-doc,missing-return-type-doc
+        roundNum = 0  # pylint: disable=invalid-name
         while 1:
+            # pylint: disable=invalid-name
             numRemovedArguments, testcase = self.tryArgumentsAsGlobals(roundNum, testcase, interesting, tempFilename)
-            roundNum += 1
+            roundNum += 1  # pylint: disable=invalid-name
 
             if numRemovedArguments and (self.minimizeRepeat == "always" or self.minimizeRepeat == "last"):
                 # Repeat with the same chunk size
@@ -955,19 +968,20 @@ class ReplaceArgumentsByGlobals(Minimize):
         return 0, False, testcase
 
     @staticmethod
-    def tryArgumentsAsGlobals(roundNum,  # pylint: disable=too-complex,too-many-branches,too-many-locals
-                              testcase, interesting, tempFilename):
+    def tryArgumentsAsGlobals(roundNum, testcase, interesting, tempFilename):  # pylint: disable=invalid-name
+        # pylint: disable=missing-param-doc,missing-return-doc,missing-return-type-doc,missing-type-doc
+        # pylint: disable=too-many-branches,too-complex,too-many-locals,too-many-statements
         """Make a single run through the testcase, trying to remove chunks of size chunkSize.
 
         Returns True iff any chunks were removed."""
 
-        numMovedArguments = 0
-        numSurvivedArguments = 0
+        numMovedArguments = 0  # pylint: disable=invalid-name
+        numSurvivedArguments = 0  # pylint: disable=invalid-name
 
         # Map words to the chunk indexes in which they are present.
         functions = {}
-        anonymousQueue = []
-        anonymousStack = []
+        anonymousQueue = []  # pylint: disable=invalid-name
+        anonymousStack = []  # pylint: disable=invalid-name
         for chunk, line in enumerate(testcase.parts):
             # Match function definition with at least one argument.
             for match in re.finditer(br"(?:function\s+(\w+)|(\w+)\s*=\s*function)\s*\((\s*\w+\s*(?:,\s*\w+\s*)*)\)",
@@ -994,6 +1008,7 @@ class ReplaceArgumentsByGlobals(Minimize):
                     args = []
                 else:
                     args = match.group(1).split(",")
+                # pylint: disable=invalid-name
                 anonymousStack += [{"defs": args, "chunk": chunk, "use": None, "useChunk": 0}]
 
             # Match calls of anonymous function.
@@ -1001,7 +1016,7 @@ class ReplaceArgumentsByGlobals(Minimize):
                 if not anonymousStack:
                     continue
                 anon = anonymousStack[-1]
-                anonymousStack = anonymousStack[:-1]
+                anonymousStack = anonymousStack[:-1]  # pylint: disable=invalid-name
                 if match.group(1) == b"" and not anon["defs"]:
                     continue
                 if match.group(1) == b"":
@@ -1010,7 +1025,7 @@ class ReplaceArgumentsByGlobals(Minimize):
                     args = match.group(1).split(b",")
                 anon["use"] = args
                 anon["useChunk"] = chunk
-                anonymousQueue += [anon]
+                anonymousQueue += [anon]  # pylint: disable=invalid-name
 
             # match function calls. (and some definitions)
             for match in re.finditer(br"((\w+)\s*\(((?:[^()]|\([^,()]*\))*)\))", line):
@@ -1030,23 +1045,23 @@ class ReplaceArgumentsByGlobals(Minimize):
 
         log.info("Starting removing function arguments.")
 
-        for fun, argsMap in functions.items():
+        for fun, argsMap in functions.items():  # pylint: disable=invalid-name
             description = "arguments of '%s'" % fun.decode("utf-8", "replace")
             if "defs" not in argsMap or not argsMap["uses"]:
                 log.info("Ignoring %s because it is 'uninteresting'.", description)
                 continue
 
-            maybeMovedArguments = 0
-            newTC = testcase.copy()
+            maybeMovedArguments = 0  # pylint: disable=invalid-name
+            newTC = testcase.copy()  # pylint: disable=invalid-name
 
             # Remove the function definition arguments
-            argDefs = argsMap["defs"]
-            defChunk = argsMap["chunk"]
+            argDefs = argsMap["defs"]  # pylint: disable=invalid-name
+            defChunk = argsMap["chunk"]  # pylint: disable=invalid-name
             subst = newTC.parts[defChunk].replace(argsMap["argsPattern"], b"", 1)
             newTC.parts = newTC.parts[:defChunk] + [subst] + newTC.parts[(defChunk + 1):]
 
             # Copy callers arguments to globals.
-            for argUse in argsMap["uses"]:
+            for argUse in argsMap["uses"]:  # pylint: disable=invalid-name
                 values = argUse["values"]
                 chunk = argUse["chunk"]
                 if chunk == defChunk and values == argDefs:
@@ -1056,46 +1071,46 @@ class ReplaceArgumentsByGlobals(Minimize):
                 setters = b"".join((a + b" = " + v + b";\n") for (a, v) in zip(argDefs, values))
                 subst = setters + newTC.parts[chunk]
                 newTC.parts = newTC.parts[:chunk] + [subst] + newTC.parts[(chunk + 1):]
-            maybeMovedArguments += len(argDefs)
+            maybeMovedArguments += len(argDefs)  # pylint: disable=invalid-name
 
             if interesting(newTC):
                 testcase = newTC
                 log.info("Yay, reduced it by removing %s :)", description)
-                numMovedArguments += maybeMovedArguments
+                numMovedArguments += maybeMovedArguments  # pylint: disable=invalid-name
             else:
-                numSurvivedArguments += maybeMovedArguments
+                numSurvivedArguments += maybeMovedArguments  # pylint: disable=invalid-name
                 log.info("Removing %s made the file 'uninteresting'.", description)
 
-            for argUse in argsMap["uses"]:
+            for argUse in argsMap["uses"]:  # pylint: disable=invalid-name
                 chunk = argUse["chunk"]
                 values = argUse["values"]
                 if chunk == defChunk and values == argDefs:
                     continue
 
-                newTC = testcase.copy()
+                newTC = testcase.copy()  # pylint: disable=invalid-name
                 subst = newTC.parts[chunk].replace(argUse["pattern"], fun + b"()", 1)
                 if newTC.parts[chunk] == subst:
                     continue
                 newTC.parts = newTC.parts[:chunk] + [subst] + newTC.parts[(chunk + 1):]
-                maybeMovedArguments = len(values)
+                maybeMovedArguments = len(values)  # pylint: disable=invalid-name
 
-                descriptionChunk = "%s at %s #%d" % (description, testcase.atom, chunk)
+                descriptionChunk = "%s at %s #%d" % (description, testcase.atom, chunk)  # pylint: disable=invalid-name
                 if interesting(newTC):
                     testcase = newTC
                     log.info("Yay, reduced it by removing %s :)", descriptionChunk)
-                    numMovedArguments += maybeMovedArguments
+                    numMovedArguments += maybeMovedArguments  # pylint: disable=invalid-name
                 else:
-                    numSurvivedArguments += maybeMovedArguments
+                    numSurvivedArguments += maybeMovedArguments  # pylint: disable=invalid-name
                     log.info("Removing %s made the file 'uninteresting'.", descriptionChunk)
 
         # Remove immediate anonymous function calls.
         for anon in anonymousQueue:
-            noopChanges = 0
-            maybeMovedArguments = 0
-            newTC = testcase.copy()
+            noopChanges = 0  # pylint: disable=invalid-name
+            maybeMovedArguments = 0  # pylint: disable=invalid-name
+            newTC = testcase.copy()  # pylint: disable=invalid-name
 
-            argDefs = anon["defs"]
-            defChunk = anon["chunk"]
+            argDefs = anon["defs"]  # pylint: disable=invalid-name
+            defChunk = anon["chunk"]  # pylint: disable=invalid-name
             values = anon["use"]
             chunk = anon["useChunk"]
             description = "arguments of anonymous function at #%s %d" % (testcase.atom, defChunk)
@@ -1103,7 +1118,7 @@ class ReplaceArgumentsByGlobals(Minimize):
             # Remove arguments of the function.
             subst = newTC.parts[defChunk].replace(b",".join(argDefs), b"", 1)
             if newTC.parts[defChunk] == subst:
-                noopChanges += 1
+                noopChanges += 1  # pylint: disable=invalid-name
             newTC.parts = newTC.parts[:defChunk] + [subst] + newTC.parts[(defChunk + 1):]
 
             # Replace arguments by their value in the scope of the function.
@@ -1112,15 +1127,15 @@ class ReplaceArgumentsByGlobals(Minimize):
             setters = b"".join(b"var %s = %s;\n" % (a, v) for a, v in zip(argDefs, values))
             subst = newTC.parts[defChunk] + b"\n" + setters
             if newTC.parts[defChunk] == subst:
-                noopChanges += 1
+                noopChanges += 1  # pylint: disable=invalid-name
             newTC.parts = newTC.parts[:defChunk] + [subst] + newTC.parts[(defChunk + 1):]
 
             # Remove arguments of the anonymous function call.
             subst = newTC.parts[chunk].replace(b",".join(anon["use"]), b"", 1)
             if newTC.parts[chunk] == subst:
-                noopChanges += 1
+                noopChanges += 1  # pylint: disable=invalid-name
             newTC.parts = newTC.parts[:chunk] + [subst] + newTC.parts[(chunk + 1):]
-            maybeMovedArguments += len(values)
+            maybeMovedArguments += len(values)  # pylint: disable=invalid-name
 
             if noopChanges == 3:
                 continue
@@ -1128,9 +1143,9 @@ class ReplaceArgumentsByGlobals(Minimize):
             if interesting(newTC):
                 testcase = newTC
                 log.info("Yay, reduced it by removing %s :)", description)
-                numMovedArguments += maybeMovedArguments
+                numMovedArguments += maybeMovedArguments  # pylint: disable=invalid-name
             else:
-                numSurvivedArguments += maybeMovedArguments
+                numSurvivedArguments += maybeMovedArguments  # pylint: disable=invalid-name
                 log.info("Removing %s made the file 'uninteresting'.", description)
 
         log.info("")
@@ -1143,38 +1158,38 @@ class ReplaceArgumentsByGlobals(Minimize):
         return numMovedArguments, testcase
 
 
-class Lithium(object):  # pylint: disable=too-many-instance-attributes
+class Lithium(object):  # pylint: disable=missing-docstring,too-many-instance-attributes
 
     def __init__(self):
 
         self.strategy = None
 
-        self.conditionScript = None
-        self.conditionArgs = None
+        self.conditionScript = None  # pylint: disable=invalid-name
+        self.conditionArgs = None  # pylint: disable=invalid-name
 
-        self.testCount = 0
-        self.testTotal = 0
+        self.testCount = 0  # pylint: disable=invalid-name
+        self.testTotal = 0  # pylint: disable=invalid-name
 
-        self.tempDir = None
+        self.tempDir = None  # pylint: disable=invalid-name
 
         self.testcase = None
-        self.lastInteresting = None
+        self.lastInteresting = None  # pylint: disable=invalid-name
 
-        self.tempFileCount = 1
+        self.tempFileCount = 1  # pylint: disable=invalid-name
 
-    def main(self, args=None):
+    def main(self, args=None):  # pylint: disable=missing-docstring,missing-return-doc,missing-return-type-doc
         logging.basicConfig(format="%(message)s", level=logging.INFO)
         self.processArgs(args)
 
         try:
             return self.run()
 
-        except LithiumError as e:
+        except LithiumError as e:  # pylint: disable=invalid-name
             summaryHeader()
             log.error(e)
             return 1
 
-    def run(self):
+    def run(self):  # pylint: disable=missing-docstring,missing-return-doc,missing-return-type-doc
         if hasattr(self.conditionScript, "init"):
             self.conditionScript.init(self.conditionArgs)
 
@@ -1198,11 +1213,11 @@ class Lithium(object):  # pylint: disable=too-many-instance-attributes
             if self.lastInteresting is not None:
                 self.lastInteresting.writeTestcase()
 
-    def processArgs(self, argv=None):  # pylint: disable=too-complex,too-many-locals
+    def processArgs(self, argv=None):  # pylint: disable=invalid-name,missing-docstring,too-complex,too-many-locals
         # Build list of strategies and testcase types
         strategies = {}
-        testcaseTypes = {}
-        for globalValue in globals().values():
+        testcaseTypes = {}  # pylint: disable=invalid-name
+        for globalValue in globals().values():  # pylint: disable=invalid-name
             if isinstance(globalValue, type):
                 if globalValue is not Strategy and issubclass(globalValue, Strategy):
                     assert globalValue.name not in strategies
@@ -1212,16 +1227,16 @@ class Lithium(object):  # pylint: disable=too-many-instance-attributes
                     testcaseTypes[globalValue.atom] = globalValue
 
         # Try to parse --conflict before anything else
-        class ArgParseTry(argparse.ArgumentParser):
+        class ArgParseTry(argparse.ArgumentParser):  # pylint: disable=missing-docstring
             def exit(subself, **kwds):  # pylint: disable=arguments-differ,no-self-argument
                 pass
 
             def error(subself, message):  # pylint: disable=no-self-argument
                 pass
 
-        defaultStrategy = "minimize"
+        defaultStrategy = "minimize"  # pylint: disable=invalid-name
         assert defaultStrategy in strategies
-        strategyParser = ArgParseTry(add_help=False)
+        strategyParser = ArgParseTry(add_help=False)  # pylint: disable=invalid-name
         strategyParser.add_argument(
             "--strategy",
             default=defaultStrategy,
@@ -1299,9 +1314,10 @@ class Lithium(object):  # pylint: disable=too-many-instance-attributes
         extra_args = args.extra_args[0]
 
         if args.testcase:
-            testcaseFilename = args.testcase
+            testcaseFilename = args.testcase  # pylint: disable=invalid-name
         elif extra_args:
-            testcaseFilename = extra_args[-1]  # can be overridden by --testcase in processOptions
+            # can be overridden by --testcase in processOptions
+            testcaseFilename = extra_args[-1]  # pylint: disable=invalid-name
         else:
             parser.error("No testcase specified (use --testcase or last condition arg)")
         self.testcase = testcaseTypes[atom]()
@@ -1316,13 +1332,14 @@ class Lithium(object):  # pylint: disable=too-many-instance-attributes
         self.conditionScript = ximport.importRelativeOrAbsolute(extra_args[0])
         self.conditionArgs = extra_args[1:]
 
-    def testcaseTempFilename(self, partialFilename, useNumber=True):
+    def testcaseTempFilename(self, partialFilename, useNumber=True):  # pylint: disable=invalid-name,missing-docstring
+        # pylint: disable=missing-return-doc,missing-return-type-doc
         if useNumber:
             partialFilename = "%d-%s" % (self.tempFileCount, partialFilename)
             self.tempFileCount += 1
         return os.path.join(self.tempDir, partialFilename + self.testcase.extension)
 
-    def createTempDir(self):
+    def createTempDir(self):  # pylint: disable=invalid-name,missing-docstring
         i = 1
         while True:
             self.tempDir = "tmp%d" % i
@@ -1335,21 +1352,22 @@ class Lithium(object):  # pylint: disable=too-many-instance-attributes
                 i += 1
 
     # If the file is still interesting after the change, changes "parts" and returns True.
-    def interesting(self, testcaseSuggestion, writeIt=True):
+    def interesting(self, testcaseSuggestion, writeIt=True):  # pylint: disable=invalid-name,missing-docstring
+        # pylint: disable=missing-return-doc,missing-return-type-doc
         if writeIt:
             testcaseSuggestion.writeTestcase()
 
         self.testCount += 1
         self.testTotal += len(testcaseSuggestion.parts)
 
-        tempPrefix = os.path.join(self.tempDir, "%d" % self.tempFileCount)
+        tempPrefix = os.path.join(self.tempDir, "%d" % self.tempFileCount)  # pylint: disable=invalid-name
         inter = self.conditionScript.interesting(self.conditionArgs, tempPrefix)
 
         # Save an extra copy of the file inside the temp directory.
         # This is useful if you're reducing an assertion and encounter a crash:
         # it gives you a way to try to reproduce the crash.
         if self.tempDir:
-            tempFileTag = "interesting" if inter else "boring"
+            tempFileTag = "interesting" if inter else "boring"  # pylint: disable=invalid-name
             testcaseSuggestion.writeTestcase(self.testcaseTempFilename(tempFileTag))
 
         if inter:
@@ -1361,30 +1379,32 @@ class Lithium(object):  # pylint: disable=too-many-instance-attributes
 
 # Helpers
 
-def summaryHeader():
+def summaryHeader():  # pylint: disable=invalid-name,missing-docstring
     log.info("=== LITHIUM SUMMARY ===")
 
 
-def divideRoundingUp(n, d):
+def divideRoundingUp(n, d):  # pylint: disable=invalid-name,missing-docstring,missing-return-doc,missing-return-type-doc
     return (n // d) + (1 if n % d != 0 else 0)
 
 
-def isPowerOfTwo(n):
+def isPowerOfTwo(n):  # pylint: disable=invalid-name,missing-docstring,missing-return-doc,missing-return-type-doc
     return (1 << max(n.bit_length() - 1, 0)) == n
 
 
-def largestPowerOfTwoSmallerThan(n):
+def largestPowerOfTwoSmallerThan(n):  # pylint: disable=invalid-name,missing-docstring
+    # pylint: disable=missing-return-doc,missing-return-type-doc
     result = 1 << max(n.bit_length() - 1, 0)
     if result == n and n > 1:
         result >>= 1
     return result
 
 
-def quantity(n, unit):
+def quantity(n, unit):  # pylint: disable=invalid-name,missing-param-doc
+    # pylint: disable=missing-return-doc,missing-return-type-doc,missing-type-doc
     """Convert a quantity to a string, with correct pluralization."""
-    r = "%d %s" % (n, unit)
+    r = "%d %s" % (n, unit)  # pylint: disable=invalid-name
     if n != 1:
-        r += "s"
+        r += "s"  # pylint: disable=invalid-name
     return r
 
 

--- a/lithium/test_lithium.py
+++ b/lithium/test_lithium.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-# pylint: disable=invalid-name,missing-docstring,missing-param-doc,missing-return-doc,missing-return-type-doc
-# pylint: disable=missing-type-doc,too-few-public-methods
+# pylint: disable=invalid-name,missing-docstring
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -46,9 +45,11 @@ class TestCase(unittest.TestCase):
     if sys.version_info.major == 2:
 
         def assertRegex(self, *args, **kwds):  # pylint: disable=arguments-differ
+            # pylint: disable=missing-return-doc,missing-return-type-doc
             return self.assertRegexpMatches(*args, **kwds)  # pylint: disable=deprecated-method
 
         def assertRaisesRegex(self, *args, **kwds):  # pylint: disable=arguments-differ
+            # pylint: disable=missing-return-doc,missing-return-type-doc
             return self.assertRaisesRegexp(*args, **kwds)  # pylint: disable=deprecated-method
 
     if sys.version_info[:2] < (3, 4):
@@ -74,7 +75,7 @@ class TestCase(unittest.TestCase):
         # AND THERE IS NO OBLIGATION WHATSOEVER TO PROVIDE MAINTENANCE,
         # SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
-        def assertLogs(self, logger=None, level=None):
+        def assertLogs(self, logger=None, level=None):  # pylint: disable=missing-return-doc,missing-return-type-doc
 
             _LoggingWatcher = collections.namedtuple("_LoggingWatcher", ["records", "output"])
 
@@ -87,7 +88,7 @@ class TestCase(unittest.TestCase):
                     self.watcher.records.append(record)
                     self.watcher.output.append(self.format(record))
 
-            class _AssertLogsContext(object):
+            class _AssertLogsContext(object):  # pylint: disable=too-few-public-methods
                 LOGGING_FORMAT = "%(levelname)s:%(name)s:%(message)s"
 
                 def __init__(self, test_case, logger_name, level):
@@ -99,7 +100,7 @@ class TestCase(unittest.TestCase):
                     self.old = None
                     self.watcher = None
 
-                def __enter__(self):
+                def __enter__(self):  # pylint: disable=missing-return-doc,missing-return-type-doc
                     if isinstance(self.logger_name, logging.Logger):
                         self.logger = self.logger_name
                     else:
@@ -113,7 +114,8 @@ class TestCase(unittest.TestCase):
                     self.logger.propagate = False
                     return handler.watcher
 
-                def __exit__(self, exc_type, exc_value, tb):
+                def __exit__(self, exc_type, exc_value, tb):  # pylint: disable=missing-return-doc
+                    # pylint: disable=missing-return-type-doc
                     self.logger.handlers, self.logger.propagate = self.old[:2]
                     self.logger.setLevel(self.old[2])
                     if exc_type is not None:
@@ -137,7 +139,7 @@ class DummyInteresting(object):
         pass
 
 
-def ispow2(n):
+def ispow2(n):  # pylint: disable=missing-param-doc,missing-return-doc,missing-return-type-doc,missing-type-doc
     """Simple version for testing
     """
     assert isinstance(n, int) or n.is_integer(), "ispow2() only works for integers, %r is not an integer" % n
@@ -159,7 +161,7 @@ def ispow2(n):
     return result
 
 
-def divceil(n, d):
+def divceil(n, d):  # pylint: disable=missing-param-doc,missing-return-doc,missing-return-type-doc,missing-type-doc
     """Simple version for testing
     """
     q = n // d
@@ -253,6 +255,7 @@ class LithiumTests(TestCase):
                 sub.init_called = True
 
             def interesting(sub, conditionArgs, tempPrefix):  # pylint: disable=no-self-argument
+                # pylint: disable=missing-return-doc,missing-return-type-doc
                 sub.interesting_called = True
                 return True
 
@@ -278,6 +281,7 @@ class LithiumTests(TestCase):
             inter = False
 
             def interesting(sub, conditionArgs, tempPrefix):  # pylint: disable=no-self-argument
+                # pylint: disable=missing-return-doc,missing-return-type-doc
                 return sub.inter
         l.conditionScript = Interesting()
         l.strategy = lithium.Minimize()
@@ -311,6 +315,7 @@ class StrategyTests(TestCase):
         class Interesting(DummyInteresting):
 
             def interesting(sub, conditionArgs, tempPrefix):  # pylint: disable=no-self-argument
+                # pylint: disable=missing-return-doc,missing-return-type-doc
                 with open("a.txt", "rb") as f:
                     return b"o\n" in f.read()
         l = lithium.Lithium()
@@ -330,6 +335,7 @@ class StrategyTests(TestCase):
         class Interesting(DummyInteresting):
 
             def interesting(sub, conditionArgs, tempPrefix):  # pylint: disable=no-self-argument
+                # pylint: disable=missing-return-doc,missing-return-type-doc
                 with open("a.txt", "rb") as f:
                     data = f.read()
                     return b"o\n" in data and len(set(data.split(b"o\n"))) == 1
@@ -350,6 +356,7 @@ class StrategyTests(TestCase):
         class Interesting(DummyInteresting):
 
             def interesting(sub, conditionArgs, tempPrefix):  # pylint: disable=no-self-argument
+                # pylint: disable=missing-return-doc,missing-return-type-doc
                 with open("a.txt", "rb") as f:
                     data = f.read()
                     if b"o\n" in data:
@@ -410,6 +417,7 @@ class StrategyTests(TestCase):
         class Interesting(DummyInteresting):
 
             def interesting(sub, conditionArgs, tempPrefix):  # pylint: disable=no-self-argument
+                # pylint: disable=missing-return-doc,missing-return-type-doc
                 with open("a.txt", "rb") as f:
                     return f.read() in valid_reductions
         l = lithium.Lithium()
@@ -442,6 +450,7 @@ class StrategyTests(TestCase):
         class Interesting(DummyInteresting):
 
             def interesting(sub, conditionArgs, tempPrefix):  # pylint: disable=no-self-argument
+                # pylint: disable=missing-return-doc,missing-return-type-doc
                 with open("a.txt", "rb") as f:
                     return f.read() in valid_reductions
         l = lithium.Lithium()

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # coding=utf-8
-# flake8: noqa
 # pylint: disable=missing-docstring
 #
 # This Source Code Form is subject to the terms of the Mozilla Public


### PR DESCRIPTION
This is a mostly-mechanical move of the pylint file-wide suppressions to be line-specific, to ensure that future code complies with standards.

Note that due to `test_lithium.py` being test-related and thus should not be used by other files, I retained the `invalid-name` and `missing-docstring` file-wide suppression. The remaining file-wide suppressions in other files seem to be related to their filename not conforming to standards, which we might change after 0.1 is released.

There is a subsequent commit to expose more existing comments as docstrings.

This should be landed before we cut 0.1, as it touches lots of lines/files yet does not change much functionality.