### PR TITLE
Strategy optimization

### DIFF
--- a/src/lithium/docs/algorithm.md
+++ b/src/lithium/docs/algorithm.md
@@ -88,6 +88,5 @@ Interestingly, Lithium doesn't know what *m* is going in, and yet its running ti
 
 It would be interesting to experiment and determine what effect each of these changes has on the running time.  (I wouldn't expect asymptotic changes, just constant-factor changes.)
 
-- Try removing chunks from the end first.
 - Use an initial chunk sizes as close as possible to half the size of the file, instead of always using power-of-2 chunk sizes.
 - Give users an option to use the "binary search for the last line" algorithm, which might be faster when application startup time dominates.

--- a/src/lithium/interestingness/utils.py
+++ b/src/lithium/interestingness/utils.py
@@ -82,7 +82,7 @@ def file_contains_regex(file_, regex, verbose=True):
     return found, matched_str
 
 
-def find_llvm_bin_path():  # pylint: disable=missing-return-doc,missing-return-type-doc
+def find_llvm_bin_path():  # pylint: disable=missing-return-doc,missing-return-type-doc,inconsistent-return-statements
     """Return the path to compiled LLVM binaries, which differs depending on compilation method."""
     if platform.system() == "Linux":
         # Assumes clang was installed through apt-get. Works with version 3.6.2,
@@ -137,8 +137,8 @@ def rel_or_abs_import(module):
     except ImportError:
         # only raise if path was given, otherwise we also try under 'interestingness'
         if path:
-            log.error("Failed to import: " + orig_arg)
-            log.error("From: " + __file__)
+            log.error("Failed to import: %s", orig_arg)
+            log.error("From: %s", __file__)
             raise
     finally:
         sys.path.pop()
@@ -147,6 +147,6 @@ def rel_or_abs_import(module):
     try:
         return importlib.import_module(".interestingness." + module, package="lithium")
     except ImportError:
-        log.error("Failed to import: .interestingness." + module)
-        log.error("From: " + __file__)
+        log.error("Failed to import: .interestingness.%s", module)
+        log.error("From: %s", __file__)
         raise

--- a/src/lithium/reducer.py
+++ b/src/lithium/reducer.py
@@ -1225,7 +1225,7 @@ class CollapseEmptyBraces(Minimize):
         Returns:
             bool: True if callback was performed successfully, False otherwise.
         """
-        raw = "".join(testcase.parts)
+        raw = b"".join(testcase.parts)
         modified = re.sub(r'{\s+}', r'{ }', raw)
 
         # Don't update the testcase if no changes were applied

--- a/src/lithium/reducer.py
+++ b/src/lithium/reducer.py
@@ -365,7 +365,7 @@ class Minimize(Strategy):
 
     def run(self, testcase, interesting, tempFilename):  # pylint: disable=invalid-name,missing-docstring
         # pylint: disable=missing-return-doc,missing-return-type-doc
-        # pylint: disable=too-many-branches,too-complex
+        # pylint: disable=too-many-branches,too-complex,too-many-statements
         chunk_size = min(self.minimizeMax, largestPowerOfTwoSmallerThan(len(testcase)))
         min_chunk_size = min(chunk_size, max(self.minimizeMin, 1))
         chunk_end = len(testcase)

--- a/src/lithium/reducer.py
+++ b/src/lithium/reducer.py
@@ -327,7 +327,7 @@ class Minimize(Strategy):
             parser.error("Min/Max must be powers of two.")
 
     @staticmethod
-    def post_round_cb(testcase):
+    def apply_post_round_op_cb(testcase):
         """ Callback function to be performed after the round ends.
         Args:
             testcase (Testcase): Testcase to be reduced.
@@ -412,7 +412,7 @@ class Minimize(Strategy):
 
                 # Perform post round clean-up if defined
                 test_to_try = testcase.copy()
-                if self.post_round_cb(test_to_try):
+                if self.apply_post_round_op_cb(test_to_try):
                     log.info("Attempting to apply post round operations to testcase")
                     if interesting(test_to_try):
                         log.info("Post round operations were successful")
@@ -1218,7 +1218,7 @@ class CollapseEmptyBraces(Minimize):
     name = "minimize-collapse-brace"
 
     @staticmethod
-    def post_round_cb(testcase):
+    def apply_post_round_op_cb(testcase):
         """ Collapse braces separated by whitespace
         Args:
             testcase (Testcase): Testcase to be reduced.

--- a/src/lithium/reducer.py
+++ b/src/lithium/reducer.py
@@ -328,10 +328,12 @@ class Minimize(Strategy):
             parser.error("Min/Max must be powers of two.")
 
     @staticmethod
-    def post_round_cb(testcase):  # pylint: missing-param-doc,missing-type-doc,unused-argument
-        """ Operation to be performed at the end of each round
-        :return: Result of applied operation
-        :rtype: bool
+    def post_round_cb(testcase):
+        """ Callback function to be performed after the round ends.
+        Args:
+            testcase (Testcase): Testcase to be reduced.
+        Returns:
+            bool: True if callback was performed successfully, False otherwise.
         """
         return False
 
@@ -386,9 +388,9 @@ class Minimize(Strategy):
                     log.info("Lithium result: succeeded, reduced to: %s", quantity(testcase.length, testcase.atom))
                     break
 
-                # If the chunk_size equals or exceeds the minimum and
+                # If the chunk_size is less than or equal to the min_chunk_size and...
                 if chunk_size <= min_chunk_size:
-                    # Repeat mode is last or always and atleast one chunk was removed during the last round, repeat
+                    # Repeat mode is last or always and at least one chunk was removed during the last round, repeat
                     if removed_chunks and (self.minimizeRepeat == "always" or self.minimizeRepeat == "last"):
                         log.info("Starting another round of chunk size %d", chunk_size)
                         chunk_end = testcase.length
@@ -429,7 +431,7 @@ class Minimize(Strategy):
             else:
                 log.info("%s made the file uninteresting", status)
                 # Decrement chunk_size
-                # To ensure file is fully reduce, decrement chunk_end by 1 when chunk_size <= 2
+                # To ensure the file is fully reduced, decrement chunk_end by 1 when chunk_size <= 2
                 if chunk_size <= 2:
                     chunk_end -= 1
                 else:
@@ -1214,7 +1216,13 @@ class CollapseEmptyBraces(Minimize):
     name = "minimize-collapse-brace"
 
     @staticmethod
-    def post_round_cb(testcase):  # pylint: disable=missing-docstring,missing-return-doc,missing-return-type-doc
+    def post_round_cb(testcase):
+        """ Collapse braces separated by whitespace
+        Args:
+            testcase (Testcase): Testcase to be reduced.
+        Returns:
+            bool: True if callback was performed successfully, False otherwise.
+        """
         raw = "".join(testcase.parts)
         modified = re.sub(r'{\s+}', r'{ }', raw)
 

--- a/src/lithium/reducer.py
+++ b/src/lithium/reducer.py
@@ -327,7 +327,7 @@ class Minimize(Strategy):
             parser.error("Min/Max must be powers of two.")
 
     @staticmethod
-    def apply_post_round_op(testcase):
+    def apply_post_round_op(testcase):  # pylint: disable=unused-argument
         """ Operations to be performed after each round
         Args:
             testcase (Testcase): Testcase to be reduced.

--- a/src/lithium/reducer.py
+++ b/src/lithium/reducer.py
@@ -1226,11 +1226,11 @@ class CollapseEmptyBraces(Minimize):
             bool: True if callback was performed successfully, False otherwise.
         """
         raw = b"".join(testcase.parts)
-        modified = re.sub(r'{\s+}', r'{ }', raw)
+        modified = re.sub(b'{\s+}', b'{ }', raw)
 
         # Don't update the testcase if no changes were applied
         if raw != modified:
-            with open(testcase.filename, 'w') as f:
+            with open(testcase.filename, 'wb') as f:
                 f.write(testcase.before)
                 f.write(modified)
                 f.write(testcase.after)

--- a/src/lithium/reducer.py
+++ b/src/lithium/reducer.py
@@ -400,7 +400,11 @@ class Minimize(Strategy):
                 # leave chunkStart the same
             else:
                 log.info("%s made the file 'uninteresting'.", description)
-                chunkStart += chunkSize
+                # To ensure file is fully reduce, increment chunkStart by 1 when chunkSize <= 2
+                if chunkSize <= 2:
+                    chunkStart += 1
+                else:
+                    chunkStart += chunkSize
 
         return 0, (chunkSize == 1 and not anyChunksRemoved and self.minimizeRepeat != "never"), testcase
 

--- a/src/lithium/reducer.py
+++ b/src/lithium/reducer.py
@@ -323,6 +323,14 @@ class Minimize(Strategy):
         if not isPowerOfTwo(self.minimizeMin) or not isPowerOfTwo(self.minimizeMax):
             parser.error("Min/Max must be powers of two.")
 
+    @staticmethod
+    def postRoundCallBack(testcase):  # pylint: disable=invalid-name,missing-param-doc,missing-type-doc,unused-argument
+        """ Operation to be performed at the end of each round
+        :return: Result of applied operation
+        :rtype: bool
+        """
+        return False
+
     def main(self, testcase, interesting, tempFilename):  # pylint: disable=missing-return-doc,missing-return-type-doc
         log.info("The original testcase has %s.", quantity(len(testcase.parts), testcase.atom))
         log.info("Checking that the original testcase is 'interesting'...")
@@ -379,14 +387,23 @@ class Minimize(Strategy):
                     break
                 else:
                     chunkStart = 0
+
                     while chunkSize > 1:  # smallest valid chunk size is 1
                         chunkSize >>= 1
                         # To avoid testing with an empty testcase (wasting cycles) only break when
                         # chunkSize is less than the number of testcase parts available.
                         if chunkSize < len(testcase.parts):
                             break
+
                     log.info("Reducing chunk size to %d", chunkSize)
                 anyChunksRemoved = False
+
+                # Perform post round clean-up if defined
+                testcaseCopy = testcase.copy()
+                if self.postRoundCallBack(testcaseCopy):
+                    log.info("Attempting to apply post round operations to testcase.")
+                    if interesting(testcaseCopy):
+                        testcase = testcaseCopy
 
             chunkEnd = min(len(testcase.parts), chunkStart + chunkSize)
             description = "Removing a chunk of size %d starting at %d of %d" % (

--- a/src/lithium/reducer.py
+++ b/src/lithium/reducer.py
@@ -1226,7 +1226,7 @@ class CollapseEmptyBraces(Minimize):
             bool: True if callback was performed successfully, False otherwise.
         """
         raw = b"".join(testcase.parts)
-        modified = re.sub(b'{\s+}', b'{ }', raw)  # pylint: disable=anomalous-backslash-in-string
+        modified = re.sub(br'{\s+}', b'{ }', raw)
 
         # Don't update the testcase if no changes were applied
         if raw != modified:

--- a/src/lithium/reducer.py
+++ b/src/lithium/reducer.py
@@ -416,7 +416,10 @@ class Minimize(Strategy):
                 if self.post_round_cb(test_to_try):
                     log.info("Attempting to apply post round operations to testcase")
                     if interesting(test_to_try):
+                        log.info("Post round operations were successful")
                         testcase = test_to_try
+                    else:
+                        log.info("Post round operations made the file uninteresting")
 
             chunk_start = max(0, chunk_end - chunk_size)
             status = "Removing chunk from %d to %d of %d" % (chunk_start, chunk_end, testcase.length)

--- a/src/lithium/reducer.py
+++ b/src/lithium/reducer.py
@@ -327,8 +327,8 @@ class Minimize(Strategy):
             parser.error("Min/Max must be powers of two.")
 
     @staticmethod
-    def apply_post_round_op_cb(testcase):
-        """ Callback function to be performed after the round ends.
+    def apply_post_round_op(testcase):
+        """ Operations to be performed after each round
         Args:
             testcase (Testcase): Testcase to be reduced.
         Returns:
@@ -412,7 +412,7 @@ class Minimize(Strategy):
 
                 # Perform post round clean-up if defined
                 test_to_try = testcase.copy()
-                if self.apply_post_round_op_cb(test_to_try):
+                if self.apply_post_round_op(test_to_try):
                     log.info("Attempting to apply post round operations to testcase")
                     if interesting(test_to_try):
                         log.info("Post round operations were successful")
@@ -1218,7 +1218,7 @@ class CollapseEmptyBraces(Minimize):
     name = "minimize-collapse-brace"
 
     @staticmethod
-    def apply_post_round_op_cb(testcase):
+    def apply_post_round_op(testcase):
         """ Collapse braces separated by whitespace
         Args:
             testcase (Testcase): Testcase to be reduced.

--- a/src/lithium/reducer.py
+++ b/src/lithium/reducer.py
@@ -1226,7 +1226,7 @@ class CollapseEmptyBraces(Minimize):
             bool: True if callback was performed successfully, False otherwise.
         """
         raw = b"".join(testcase.parts)
-        modified = re.sub(b'{\s+}', b'{ }', raw)
+        modified = re.sub(b'{\s+}', b'{ }', raw)  # pylint: disable=anomalous-backslash-in-string
 
         # Don't update the testcase if no changes were applied
         if raw != modified:

--- a/src/lithium/reducer.py
+++ b/src/lithium/reducer.py
@@ -1231,7 +1231,9 @@ class CollapseEmptyBraces(Minimize):
         # Don't update the testcase if no changes were applied
         if raw != modified:
             with open(testcase.filename, 'w') as f:
+                f.write(testcase.before)
                 f.write(modified)
+                f.write(testcase.after)
 
             # Re-parse the modified testcase
             testcase.readTestcase(testcase.filename)

--- a/src/lithium/reducer.py
+++ b/src/lithium/reducer.py
@@ -328,7 +328,7 @@ class Minimize(Strategy):
             parser.error("Min/Max must be powers of two.")
 
     @staticmethod
-    def post_round_cb(testcase):  # pylint: disable=invalid-name,missing-param-doc,missing-type-doc,unused-argument
+    def post_round_cb(testcase):  # pylint: missing-param-doc,missing-type-doc,unused-argument
         """ Operation to be performed at the end of each round
         :return: Result of applied operation
         :rtype: bool

--- a/src/lithium/reducer.py
+++ b/src/lithium/reducer.py
@@ -1187,6 +1187,38 @@ class ReplaceArgumentsByGlobals(Minimize):
         return numMovedArguments, testcase
 
 
+class CollapseEmptyBraces(Minimize):
+    """ Perform standard line based reduction but collapse empty braces at the end of each round
+    This ensures that empty braces are reduced in a single pass of the reduction strategy
+
+    Example:
+        // Original
+        function foo() {
+        }
+
+        // Post-processed
+        function foo() { }
+    """
+    name = "minimize-collapse-brace"
+
+    @staticmethod
+    def postRoundCallBack(testcase):  # pylint: disable=missing-docstring,missing-return-doc,missing-return-type-doc
+        raw = "".join(testcase.parts)
+        modified = re.sub(r'{\s+}', r'{ }', raw)
+
+        # Don't update the testcase if no changes were applied
+        if raw != modified:
+            with open(testcase.filename, 'w') as f:
+                f.write(modified)
+
+            # Re-parse the modified testcase
+            testcase.readTestcase(testcase.filename)
+
+            return True
+
+        return False
+
+
 class Lithium(object):  # pylint: disable=missing-docstring,too-many-instance-attributes
 
     def __init__(self):

--- a/src/lithium/reducer.py
+++ b/src/lithium/reducer.py
@@ -364,6 +364,7 @@ class Minimize(Strategy):
 
     def run(self, testcase, interesting, tempFilename):  # pylint: disable=invalid-name,missing-docstring
         # pylint: disable=missing-return-doc,missing-return-type-doc
+        # pylint: disable=too-many-branches,too-complex
         chunk_size = min(self.minimizeMax, largestPowerOfTwoSmallerThan(testcase.length))
         min_chunk_size = min(chunk_size, max(self.minimizeMin, 1))
         chunk_end = testcase.length

--- a/src/lithium/reducer.py
+++ b/src/lithium/reducer.py
@@ -328,7 +328,7 @@ class Minimize(Strategy):
             parser.error("Min/Max must be powers of two.")
 
     @staticmethod
-    def postRoundCallBack(testcase):  # pylint: disable=invalid-name,missing-param-doc,missing-type-doc,unused-argument
+    def post_round_cb(testcase):  # pylint: disable=invalid-name,missing-param-doc,missing-type-doc,unused-argument
         """ Operation to be performed at the end of each round
         :return: Result of applied operation
         :rtype: bool
@@ -411,7 +411,7 @@ class Minimize(Strategy):
 
                 # Perform post round clean-up if defined
                 temp_testcase = testcase.copy()
-                if self.postRoundCallBack(temp_testcase):
+                if self.post_round_cb(temp_testcase):
                     log.info("Attempting to apply post round operations to testcase.")
                     if interesting(temp_testcase):
                         testcase = temp_testcase
@@ -1214,7 +1214,7 @@ class CollapseEmptyBraces(Minimize):
     name = "minimize-collapse-brace"
 
     @staticmethod
-    def postRoundCallBack(testcase):  # pylint: disable=missing-docstring,missing-return-doc,missing-return-type-doc
+    def post_round_cb(testcase):  # pylint: disable=missing-docstring,missing-return-doc,missing-return-type-doc
         raw = "".join(testcase.parts)
         modified = re.sub(r'{\s+}', r'{ }', raw)
 

--- a/src/lithium/reducer.py
+++ b/src/lithium/reducer.py
@@ -412,22 +412,22 @@ class Minimize(Strategy):
                 # Perform post round clean-up if defined
                 temp_testcase = testcase.copy()
                 if self.post_round_cb(temp_testcase):
-                    log.info("Attempting to apply post round operations to testcase.")
+                    log.info("Attempting to apply post round operations to testcase")
                     if interesting(temp_testcase):
                         testcase = temp_testcase
 
             chunk_start = max(0, chunk_end - chunk_size)
-            status = "Removing chunk [%d:%d] of %d" % (chunk_start, chunk_end, testcase.length)
+            status = "Removing chunk from %d to %d of %d" % (chunk_start, chunk_end, testcase.length)
             temp_testcase = testcase.copy()
             temp_testcase.parts = temp_testcase.parts[:chunk_start] + temp_testcase.parts[chunk_end:]
 
             if interesting(temp_testcase):
                 testcase = temp_testcase
-                log.info("%s was a successful.", status)
+                log.info("%s was successful", status)
                 removed_chunks = True
                 chunk_end = chunk_start
             else:
-                log.info("%s made the file uninteresting.", status)
+                log.info("%s made the file uninteresting", status)
                 # Decrement chunk_size
                 # To ensure file is fully reduce, decrement chunk_end by 1 when chunk_size <= 2
                 if chunk_size <= 2:

--- a/src/lithium/reducer.py
+++ b/src/lithium/reducer.py
@@ -412,19 +412,19 @@ class Minimize(Strategy):
                 removed_chunks = False
 
                 # Perform post round clean-up if defined
-                temp_testcase = testcase.copy()
-                if self.post_round_cb(temp_testcase):
+                test_to_try = testcase.copy()
+                if self.post_round_cb(test_to_try):
                     log.info("Attempting to apply post round operations to testcase")
-                    if interesting(temp_testcase):
-                        testcase = temp_testcase
+                    if interesting(test_to_try):
+                        testcase = test_to_try
 
             chunk_start = max(0, chunk_end - chunk_size)
             status = "Removing chunk from %d to %d of %d" % (chunk_start, chunk_end, testcase.length)
-            temp_testcase = testcase.copy()
-            temp_testcase.parts = temp_testcase.parts[:chunk_start] + temp_testcase.parts[chunk_end:]
+            test_to_try = testcase.copy()
+            test_to_try.parts = test_to_try.parts[:chunk_start] + test_to_try.parts[chunk_end:]
 
-            if interesting(temp_testcase):
-                testcase = temp_testcase
+            if interesting(test_to_try):
+                testcase = test_to_try
                 log.info("%s was successful", status)
                 removed_chunks = True
                 chunk_end = chunk_start

--- a/tests/test_lithium.py
+++ b/tests/test_lithium.py
@@ -704,22 +704,32 @@ class StrategyTests(TestCase):
                 # pylint: disable=missing-return-doc,missing-return-type-doc
                 with open("a.txt", "rb") as f:
                     data = f.read()
-                    if b"o\n" in data:
-                        return data.count(b"{") == data.count(b"}")
+                    if conditionArgs == 'NEEDS_BRACE':
+                        return data.count(b"{") == 1 and data.count(b"{") == data.count(b"}")
+                    elif conditionArgs == 'NO_BRACE':
+                        if b"o\n" in data:
+                            return data.count(b"{") == data.count(b"}")
                     return False
-        l = lithium.Lithium()  # noqa: E741
-        l.conditionScript = Interesting()
-        l.strategy = lithium.CollapseEmptyBraces()
         # CollapseEmptyBraces only applies to line-based reduction
         log.info("Trying with testcase type %s:", lithium.TestcaseLine.__name__)
-        with open("a.txt", "wb") as f:
-            f.write(b"x\nxxx{\nx\n}\no\n")
-        l.testcase = lithium.TestcaseLine()
-        l.testcase.readTestcase("a.txt")
-        self.assertEqual(l.run(), 0)
-        self.assertEqual(l.testCount, 16)
-        with open("a.txt", "rb") as f:
-            self.assertEqual(f.read(), b"o\n")
+        for test_type in ['NEEDS_BRACE', 'NO_BRACE']:
+            l = lithium.Lithium()  # noqa: E741
+            l.conditionScript = Interesting()
+            l.conditionArgs = test_type
+            l.strategy = lithium.CollapseEmptyBraces()
+            with open("a.txt", "wb") as f:
+                f.write(b"x\nxxx{\nx\n}\no\n")
+            l.testcase = lithium.TestcaseLine()
+            l.testcase.readTestcase("a.txt")
+            self.assertEqual(l.run(), 0)
+            if test_type == 'NEEDS_BRACE':
+                self.assertEqual(l.testCount, 15)
+                with open("a.txt", "rb") as f:
+                    self.assertEqual(f.read(), b"xxx{ }\n")
+            elif test_type == 'NO_BRACE':
+                self.assertEqual(l.testCount, 16)
+                with open("a.txt", "rb") as f:
+                    self.assertEqual(f.read(), b"o\n")
 
 
 class TestcaseTests(TestCase):

--- a/tests/test_lithium.py
+++ b/tests/test_lithium.py
@@ -123,8 +123,8 @@ class TestCase(unittest.TestCase):
                     self.logger.propagate = False
                     return handler.watcher
 
-                def __exit__(self, exc_type, exc_value, tb):  # pylint: disable=missing-return-doc
-                    # pylint: disable=missing-return-type-doc
+                def __exit__(self, exc_type, exc_value, tb):  # pylint: disable=inconsistent-return-statements
+                    # pylint: disable=missing-return-doc,missing-return-type-doc
                     self.logger.handlers, self.logger.propagate = self.old[:2]
                     self.logger.setLevel(self.old[2])
                     if exc_type is not None:


### PR DESCRIPTION
This commit adds a number of improvements to the primary reduction strategy:
- Increment chunk_start by 1 instead of power of 2 when chunk_size <= 2
- Reduce from bottom up
- Add callback for performing actions at end of pass

Also included in this commit is a new reduction strategy which uses the postRoundCallBack for collapsing empty curly braces as an add-on to the primary reduction strategy.