### PR TITLE
Make timed_run accept environment variables to be added

### DIFF
--- a/src/lithium/interestingness/timed_run.py
+++ b/src/lithium/interestingness/timed_run.py
@@ -132,8 +132,8 @@ def timed_run(cmd_with_args, timeout, log_prefix, env=None, inp=None, preexec_fn
         if return_code is None:
             if elapsedtime > timeout and not killed:
                 if progname == "gdb":
-                    raise Exception("Do not use this with gdb, because xpkill in timed_run will "
-                                    "kill gdb but leave the process within gdb still running")
+                    raise OSError("Do not use this with gdb, because xpkill in timed_run will "
+                                  "kill gdb but leave the process within gdb still running")
                 xpkill(child)
                 # but continue looping, because maybe kill takes a few seconds or maybe it's busy crashing!
                 killed = True

--- a/src/lithium/interestingness/timed_run.py
+++ b/src/lithium/interestingness/timed_run.py
@@ -46,19 +46,19 @@ class rundata(object):  # pylint: disable=invalid-name,missing-param-doc,missing
         self.err = err
 
 
-def xpkill(p):  # pylint: disable=invalid-name,missing-param-doc,missing-type-doc
+def xpkill(proc):  # pylint: disable=missing-param-doc,missing-type-doc
     """Based on mozilla-central/source/build/automation.py.in ."""
     try:
-        p.kill()
+        proc.kill()
     except WindowsError:  # pylint: disable=undefined-variable
-        if p.poll() == 0:
+        if proc.poll() == 0:
             try:
                 print("Trying to kill the process the first time...")
-                p.kill()  # Verify that the process is really killed.
+                proc.kill()  # Verify that the process is really killed.
             except WindowsError:  # pylint: disable=undefined-variable
-                if p.poll() == 0:
+                if proc.poll() == 0:
                     print("Trying to kill the process the second time...")
-                    p.kill()  # Re-verify that the process is really killed.
+                    proc.kill()  # Re-verify that the process is really killed.
 
 
 def make_env(bin_path, curr_env=None):  # pylint: disable=missing-docstring,missing-return-doc,missing-return-type-doc

--- a/src/lithium/interestingness/timed_run.py
+++ b/src/lithium/interestingness/timed_run.py
@@ -81,7 +81,7 @@ def timed_run(cmd_with_args, timeout, log_prefix, env=None, inp=None, preexec_fn
     if not isinstance(timeout, int):
         raise TypeError("timeout should be an int.")
 
-    useLogFiles = isinstance(log_prefix, str)  # pylint: disable=invalid-name
+    use_logfiles = isinstance(log_prefix, ("".__class__, u"".__class__))
 
     cmd_with_args[0] = os.path.expanduser(cmd_with_args[0])
     progname = cmd_with_args[0].split(os.path.sep)[-1]

--- a/src/lithium/interestingness/timed_run.py
+++ b/src/lithium/interestingness/timed_run.py
@@ -77,9 +77,24 @@ def make_env(bin_path, curr_env=None):  # pylint: disable=missing-docstring,miss
 
 
 def timed_run(cmd_with_args, timeout, log_prefix, env=None, inp=None, preexec_fn=None):
-    # pylint: disable=missing-param-doc,missing-raises-doc,missing-return-doc,missing-return-type-doc,missing-type-doc
-    # pylint: disable=too-complex,too-many-branches,too-many-locals,too-many-statements
-    """If log_prefix is None, uses pipes instead of files for all output."""
+    # pylint: disable=too-complex,too-many-arguments,too-many-branches,too-many-locals,too-many-statements
+    """If log_prefix is None, uses pipes instead of files for all output.
+
+    Args:
+        cmd_with_args (list): List of command and parameters to be executed
+        timeout (int): Timeout for the command to be run, in seconds
+        log_prefix (str): Prefix string of the log files
+        env (dict): Environment for the commmand to be executed in
+        inp (str): stdin to be passed to the command
+        preexec_fn (function): preexec_fn to be passed to subprocess.Popen
+
+    Raises:
+        TypeError: Raises if input parameters are not of the desired types (e.g. cmd_with_args should be a list)
+        OSError: Raises if timed_run is attempted to be used with gdb
+
+    Returns:
+        class: A rundata instance containing run information
+    """
     if not isinstance(cmd_with_args, list):
         raise TypeError("cmd_with_args should be a list (of strings).")
     if not isinstance(timeout, int):

--- a/src/lithium/interestingness/timed_run.py
+++ b/src/lithium/interestingness/timed_run.py
@@ -100,7 +100,7 @@ def timed_run(cmd_with_args, timeout, log_prefix, env=None, inp=None, preexec_fn
     if not isinstance(timeout, int):
         raise TypeError("timeout should be an int.")
 
-    use_logfiles = isinstance(log_prefix, ("".__class__, u"".__class__))
+    use_logfiles = isinstance(log_prefix, str)
 
     cmd_with_args[0] = os.path.expanduser(cmd_with_args[0])
     progname = cmd_with_args[0].split(os.path.sep)[-1]

--- a/src/lithium/interestingness/timed_run.py
+++ b/src/lithium/interestingness/timed_run.py
@@ -77,39 +77,39 @@ def make_env(bin_path):  # pylint: disable=missing-docstring,missing-return-doc,
     return env
 
 
-def timed_run(commandWithArgs, timeout, logPrefix, inp=None, preexec_fn=None):  # pylint: disable=invalid-name
+def timed_run(cmd_with_args, timeout, log_prefix, inp=None, preexec_fn=None):
     # pylint: disable=missing-param-doc,missing-raises-doc,missing-return-doc,missing-return-type-doc,missing-type-doc
     # pylint: disable=too-complex,too-many-branches,too-many-locals,too-many-statements
-    """If logPrefix is None, uses pipes instead of files for all output."""
-    if not isinstance(commandWithArgs, list):
-        raise TypeError("commandWithArgs should be a list (of strings).")
+    """If log_prefix is None, uses pipes instead of files for all output."""
+    if not isinstance(cmd_with_args, list):
+        raise TypeError("cmd_with_args should be a list (of strings).")
     if not isinstance(timeout, int):
         raise TypeError("timeout should be an int.")
 
-    useLogFiles = isinstance(logPrefix, str)  # pylint: disable=invalid-name
+    useLogFiles = isinstance(log_prefix, str)  # pylint: disable=invalid-name
 
-    commandWithArgs[0] = os.path.expanduser(commandWithArgs[0])
-    progname = commandWithArgs[0].split(os.path.sep)[-1]
+    cmd_with_args[0] = os.path.expanduser(cmd_with_args[0])
+    progname = cmd_with_args[0].split(os.path.sep)[-1]
 
     starttime = time.time()
 
     if useLogFiles:
-        childStdOut = open(logPrefix + "-out.txt", "w")  # pylint: disable=invalid-name
-        childStdErr = open(logPrefix + "-err.txt", "w")  # pylint: disable=invalid-name
+        childStdOut = open(log_prefix + "-out.txt", "w")  # pylint: disable=invalid-name
+        childStdErr = open(log_prefix + "-err.txt", "w")  # pylint: disable=invalid-name
 
     try:
         child = subprocess.Popen(
-            commandWithArgs,
+            cmd_with_args,
             stdin=(None if (inp is None) else subprocess.PIPE),
             stderr=(childStdErr if useLogFiles else subprocess.PIPE),
             stdout=(childStdOut if useLogFiles else subprocess.PIPE),
             close_fds=(os.name == "posix"),  # close_fds should not be changed on Windows
-            env=make_env(commandWithArgs[0]),
+            env=make_env(cmd_with_args[0]),
             preexec_fn=preexec_fn
         )
     except OSError as e:  # pylint: disable=invalid-name
         print("Tried to run:")
-        print("  %r" % commandWithArgs)
+        print("  %r" % cmd_with_args)
         print("but got this error:")
         print("  %s" % e)
         sys.exit(2)
@@ -178,6 +178,6 @@ def timed_run(commandWithArgs, timeout, logPrefix, inp=None, preexec_fn=None):  
         elapsedtime,
         killed,
         child.pid,
-        logPrefix + "-out.txt" if useLogFiles else child.stdout.read(),
-        logPrefix + "-err.txt" if useLogFiles else child.stderr.read()
+        log_prefix + "-out.txt" if useLogFiles else child.stdout.read(),
+        log_prefix + "-err.txt" if useLogFiles else child.stderr.read()
     )

--- a/src/lithium/interestingness/timed_run.py
+++ b/src/lithium/interestingness/timed_run.py
@@ -107,26 +107,25 @@ def timed_run(cmd_with_args, timeout, log_prefix, env=None, inp=None, preexec_fn
 
     starttime = time.time()
 
-    if useLogFiles:
-        childStdOut = open(log_prefix + "-out.txt", "w")  # pylint: disable=invalid-name
-        childStdErr = open(log_prefix + "-err.txt", "w")  # pylint: disable=invalid-name
-
+    if use_logfiles:
+        child_stdout = open(log_prefix + "-out.txt", "w")
+        child_stderr = open(log_prefix + "-err.txt", "w")
 
     try:
         child = subprocess.Popen(
             cmd_with_args,
             stdin=(None if (inp is None) else subprocess.PIPE),
-            stderr=(childStdErr if useLogFiles else subprocess.PIPE),
-            stdout=(childStdOut if useLogFiles else subprocess.PIPE),
+            stderr=(child_stderr if use_logfiles else subprocess.PIPE),
+            stdout=(child_stdout if use_logfiles else subprocess.PIPE),
             close_fds=(os.name == "posix"),  # close_fds should not be changed on Windows
             env=(env or make_env(cmd_with_args[0], os.environ)),
             preexec_fn=preexec_fn
         )
-    except OSError as e:  # pylint: disable=invalid-name
+    except OSError as ex:
         print("Tried to run:")
         print("  %r" % cmd_with_args)
         print("but got this error:")
-        print("  %s" % e)
+        print("  %s" % ex)
         sys.exit(2)
 
     if inp is not None:
@@ -181,10 +180,10 @@ def timed_run(cmd_with_args, timeout, log_prefix, env=None, inp=None, preexec_fn
         msg = "CRASHED signal %d (%s)" % (signum, get_signal_name(signum, "Unknown signal"))
         sta = CRASHED
 
-    if useLogFiles:
+    if use_logfiles:
         # Am I supposed to do this?
-        childStdOut.close()
-        childStdErr.close()
+        child_stdout.close()
+        child_stderr.close()
 
     return rundata(
         sta,
@@ -193,6 +192,6 @@ def timed_run(cmd_with_args, timeout, log_prefix, env=None, inp=None, preexec_fn
         elapsedtime,
         killed,
         child.pid,
-        log_prefix + "-out.txt" if useLogFiles else child.stdout.read(),
-        log_prefix + "-err.txt" if useLogFiles else child.stderr.read()
+        log_prefix + "-out.txt" if use_logfiles else child.stdout.read(),
+        log_prefix + "-err.txt" if use_logfiles else child.stderr.read()
     )

--- a/src/lithium/interestingness/timed_run.py
+++ b/src/lithium/interestingness/timed_run.py
@@ -46,8 +46,12 @@ class rundata(object):  # pylint: disable=invalid-name,missing-param-doc,missing
         self.err = err
 
 
-def xpkill(proc):  # pylint: disable=missing-param-doc,missing-type-doc
-    """Based on mozilla-central/source/build/automation.py.in ."""
+def xpkill(proc):
+    """Based on mozilla-central/source/build/automation.py.in .
+
+    Args:
+        proc (process): Process to be killed
+    """
     try:
         proc.kill()
     except WindowsError:  # pylint: disable=undefined-variable


### PR DESCRIPTION
This makes timed_run accept environment variables to be added to the current environment when the subprocess command is executed. A bunch of linter errors are fixed too.

This is a prerequisite to getting code coverage support in the funfuzz harness.