### PR TITLE
Use str.splitlines consistently when splitting testcases

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,26 +1,26 @@
 repos:
   - repo: https://github.com/pycqa/isort
-    rev: 5.6.4
+    rev: 5.8.0
     hooks:
       - id: isort
   - repo: https://github.com/asottile/yesqa
-    rev: v1.2.2
+    rev: v1.2.3
     hooks:
       - id: yesqa
   - repo: https://github.com/ambv/black
-    rev: 20.8b1
+    rev: 21.6b0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/pylint
-    rev: pylint-2.6.0
+    rev: v2.8.3
     hooks:
       - id: pylint
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 3.9.2
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.0.1
     hooks:
       - id: check-ast
       - id: check-docstring-first
@@ -36,7 +36,7 @@ repos:
         args: ['--django']
       - id: check-json
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.0.0
+    rev: v2.1.0
     hooks:
       - id: codespell
         exclude_types: [json]

--- a/src/lithium/interestingness/timed_run.py
+++ b/src/lithium/interestingness/timed_run.py
@@ -105,11 +105,13 @@ def timed_run(
 
     child_stdout = child_stderr = subprocess.PIPE
     if log_prefix is not None:
+        # pylint: disable=consider-using-with
         child_stdout = open(log_prefix + "-out.txt", "wb")
         child_stderr = open(log_prefix + "-err.txt", "wb")
 
     start_time = time.time()
-    child = subprocess.Popen(  # pylint: disable=subprocess-popen-preexec-fn
+    # pylint: disable=consider-using-with,subprocess-popen-preexec-fn
+    child = subprocess.Popen(
         cmd_with_args,
         env=env,
         stderr=child_stderr,

--- a/src/lithium/reducer.py
+++ b/src/lithium/reducer.py
@@ -248,7 +248,7 @@ class Lithium:
         return self.temp_dir / (filename_stem + self.testcase.extension)
 
     def create_temp_dir(self):
-        """Create and switch to the next available temporary working folder. """
+        """Create and switch to the next available temporary working folder."""
         i = 1
         while True:
             temp_dir = Path("tmp%d" % (i,))

--- a/src/lithium/testcases.py
+++ b/src/lithium/testcases.py
@@ -424,7 +424,11 @@ class TestcaseAttrs(Testcase):
 
                 if match is None or match.group(0).strip() == b">":
                     in_tag = False
-                    LOG.debug("no attribute found (%r), looking for other tags", match)
+                    LOG.debug(
+                        "no attribute found (%r) in %r..., looking for other tags",
+                        match,
+                        data[:20],
+                    )
                     if match is not None:
                         self.parts.append(data[: match.end(0)])
                         self.reducible.append(False)
@@ -468,7 +472,7 @@ class TestcaseAttrs(Testcase):
                 data = data[end:]
                 self.parts.append(b"".join(attr_parts))
                 self.reducible.append(True)
-                LOG.debug("found attribute")
+                LOG.debug("found attribute: %r", self.parts[-1])
             else:
                 match = re.search(self.TAG_PATTERN, data)
                 if match is None:


### PR DESCRIPTION
Particularly when searching for DDBEGIN/END lines.

`str.splitlines` recognizes a bunch of extra possible newlines: https://docs.python.org/3/library/stdtypes.html?highlight=str%20splitlines#str.splitlines