### PR TITLE
Allow newer versions of FFPuppet

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ url = https://github.com/MozillaSecurity/lithium
 
 [options]
 install_requires =
-    ffpuppet~=0.11.2
+    ffpuppet>=0.11.2
 package_dir =
     = src
 packages =


### PR DESCRIPTION
Other projects depend on Lithium and FFPuppet and this will help avoid dependency issues.